### PR TITLE
restatectl: capture best-effort cluster backup descriptors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9381,6 +9381,7 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tonic",
  "tracing",
+ "url",
  "vergen",
 ]
 

--- a/crates/admin/src/cluster_controller/grpc_svc_handler.rs
+++ b/crates/admin/src/cluster_controller/grpc_svc_handler.rs
@@ -45,7 +45,6 @@ use restate_types::logs::{LogId, Lsn, SequenceNumber};
 use restate_types::metadata::{GlobalMetadata, Precondition};
 use restate_types::metadata_store::keys::{NODES_CONFIG_KEY, partition_processor_epoch_key};
 use restate_types::net::connect_opts::GrpcConnectionOptions;
-use restate_types::net::partition_processor_manager::Snapshot;
 use restate_types::nodes_config::{NodesConfiguration, Role};
 use restate_types::partitions::PartitionTable;
 use restate_types::partitions::state::PartitionReplicaSetStates;
@@ -208,6 +207,7 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
                 partition_id,
                 request.min_target_lsn.map(Into::into),
                 request.trim_log,
+                request.protect_from_retention,
             )
             .await
             .map_err(|_| Status::aborted("Node is shutting down"))?
@@ -216,14 +216,12 @@ impl ClusterCtrlSvc for ClusterCtrlSvcHandler {
                 info!("Failed to create partition snapshot: {err}");
                 Err(Status::internal(err.to_string()))
             }
-            Ok(Snapshot {
-                snapshot_id,
-                log_id,
-                min_applied_lsn,
-            }) => Ok(Response::new(CreatePartitionSnapshotResponse {
-                snapshot_id: snapshot_id.to_string(),
-                log_id: log_id.into(),
-                min_applied_lsn: min_applied_lsn.as_u64(),
+            Ok(snapshot) => Ok(Response::new(CreatePartitionSnapshotResponse {
+                snapshot_id: snapshot.snapshot_id.to_string(),
+                log_id: snapshot.log_id.into(),
+                min_applied_lsn: snapshot.exact_min_applied_lsn().as_u64(),
+                trim_safe_lsn: snapshot.min_applied_lsn.as_u64(),
+                snapshot_repository: snapshot.snapshot_repository,
             })),
         }
     }

--- a/crates/admin/src/cluster_controller/service.rs
+++ b/crates/admin/src/cluster_controller/service.rs
@@ -195,6 +195,7 @@ enum ClusterControllerCommand {
     CreateSnapshot {
         partition_id: PartitionId,
         min_target_lsn: Option<Lsn>,
+        protect_from_retention: bool,
         response_tx: oneshot::Sender<anyhow::Result<Snapshot>>,
     },
     UpdateClusterConfiguration {
@@ -262,6 +263,7 @@ impl ClusterControllerHandle {
         partition_id: PartitionId,
         min_target_lsn: Option<Lsn>,
         trim_log: bool,
+        protect_from_retention: bool,
     ) -> Result<anyhow::Result<Snapshot>, ShutdownError> {
         let (response_tx, response_rx) = oneshot::channel();
 
@@ -277,6 +279,7 @@ impl ClusterControllerHandle {
             .send(ClusterControllerCommand::CreateSnapshot {
                 partition_id,
                 min_target_lsn,
+                protect_from_retention,
                 response_tx,
             })
             .await;
@@ -286,6 +289,8 @@ impl ClusterControllerHandle {
         if let (Ok(snapshot), true) = (&create_snapshot_response, trim_log) {
             // We have successfully archived the target LSN to the snapshot repository. For added
             // safety, we could optionally download and test the snapshot in the future.
+            // This field deliberately retains its legacy trim-safe meaning for old and new
+            // workers. Exact snapshot identity is carried separately.
             if let Err(trim_error) = self.trim_log(log_id, snapshot.min_applied_lsn).await? {
                 return Ok(Err(trim_error));
             }
@@ -441,6 +446,7 @@ impl<T: TransportConnect> Service<T> {
         &self,
         partition_id: PartitionId,
         min_target_lsn: Option<Lsn>,
+        protect_from_retention: bool,
         response_tx: oneshot::Sender<anyhow::Result<Snapshot>>,
     ) {
         let cluster_state = self.cluster_state_refresher.get_cluster_state();
@@ -478,6 +484,7 @@ impl<T: TransportConnect> Service<T> {
                                     node.generational_node_id,
                                     partition_id,
                                     min_target_lsn,
+                                    protect_from_retention,
                                 )
                                 .await,
                         );
@@ -522,12 +529,14 @@ impl<T: TransportConnect> Service<T> {
             ClusterControllerCommand::CreateSnapshot {
                 partition_id,
                 min_target_lsn,
+                protect_from_retention,
                 response_tx,
             } => {
                 info!(?partition_id, "Create snapshot command received");
                 self.spawn_create_partition_snapshot_task(
                     partition_id,
                     min_target_lsn,
+                    protect_from_retention,
                     response_tx,
                 );
             }
@@ -768,6 +777,7 @@ where
         node_id: GenerationalNodeId,
         partition_id: PartitionId,
         min_target_lsn: Option<Lsn>,
+        protect_from_retention: bool,
     ) -> anyhow::Result<Snapshot> {
         self.network_sender
             .call_rpc(
@@ -776,6 +786,7 @@ where
                 CreateSnapshotRequest {
                     partition_id,
                     min_target_lsn,
+                    protect_from_retention,
                 },
                 Some(partition_id.into()),
                 None,

--- a/crates/core/protobuf/cluster_ctrl_svc.proto
+++ b/crates/core/protobuf/cluster_ctrl_svc.proto
@@ -110,6 +110,10 @@ message CreatePartitionSnapshotRequest {
   // successful snapshot and so will honor the min_target_lsn requirement, if
   // set to true
   bool trim_log = 3;
+  // Protect the created snapshot from the repository's rolling retention policy.
+  // Protected snapshots remain until explicitly removed by an operator or a future
+  // backup lifecycle API.
+  bool protect_from_retention = 4;
 }
 
 message CreatePartitionSnapshotResponse {
@@ -117,6 +121,12 @@ message CreatePartitionSnapshotResponse {
   uint32 log_id = 2;
   // Minimum LSN (inclusive) which is guaranteed to be covered by the snapshot
   uint64 min_applied_lsn = 3;
+  // Oldest LSN covered by every retained snapshot. This is the safe log trim point
+  // when older snapshots remain available in the repository.
+  uint64 trim_safe_lsn = 4;
+  // Authoritative normalized repository destination used by the worker. Credentials and
+  // query parameters are excluded.
+  string snapshot_repository = 5;
 }
 
 message ChainExtension {

--- a/crates/partition-store/src/snapshots.rs
+++ b/crates/partition-store/src/snapshots.rs
@@ -18,7 +18,9 @@ use std::sync::Arc;
 use crate::{PartitionDb, PartitionStore, SnapshotError, SnapshotErrorKind};
 
 pub use self::metadata::*;
-pub use self::repository::{PartitionSnapshotStatus, SnapshotRepository};
+pub use self::repository::{
+    PartitionSnapshotStatus, SnapshotRecord, SnapshotRepository, SnapshotSource,
+};
 pub use self::snapshot_task::*;
 
 use tokio::sync::Semaphore;

--- a/crates/partition-store/src/snapshots/repository.rs
+++ b/crates/partition-store/src/snapshots/repository.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use ahash::{HashMap, HashMapExt};
 use anyhow::{Context, anyhow, bail};
 use bytes::BytesMut;
+use futures::future::BoxFuture;
 use object_store::path::Path as ObjectPath;
 use object_store::{
     MultipartUpload, ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload, UpdateVersion,
@@ -67,6 +68,46 @@ pub struct SnapshotRepository {
     enable_cleanup: bool,
 }
 
+/// Identity of the cluster that produced snapshots being restored.
+///
+/// This is deliberately supplied by the caller rather than inferred from the
+/// running node. A restore target can have a newly generated fingerprint.
+#[derive(Clone, Debug)]
+pub struct SnapshotSource {
+    cluster_name: String,
+    cluster_fingerprint: Option<ClusterFingerprint>,
+}
+
+/// An immutable snapshot selected during restore preflight.
+///
+/// Its metadata lets callers validate topology before any SST is downloaded. The repository
+/// path remains private so only this module can turn a validated record into a download.
+#[derive(Clone, Debug)]
+pub struct SnapshotRecord {
+    pub partition_id: PartitionId,
+    pub snapshot_id: SnapshotId,
+    pub min_applied_lsn: Lsn,
+    pub metadata: PartitionSnapshotMetadata,
+    path: String,
+}
+
+impl SnapshotSource {
+    pub fn new(cluster_name: String, cluster_fingerprint: Option<ClusterFingerprint>) -> Self {
+        Self {
+            cluster_name,
+            cluster_fingerprint,
+        }
+    }
+
+    fn validate_latest(&self, latest: &LatestSnapshot) -> anyhow::Result<()> {
+        latest.validate(&self.cluster_name, self.cluster_fingerprint)
+    }
+
+    fn validate_metadata(&self, metadata: &PartitionSnapshotMetadata) -> anyhow::Result<()> {
+        metadata.validate(&self.cluster_name, self.cluster_fingerprint)
+    }
+}
+
 /// S3 and other stores require a certain minimum size for the parts of a multipart upload. It is an
 /// API error to attempt a multipart put below this size, apart from the final segment.
 const MULTIPART_UPLOAD_CHUNK_SIZE_BYTES: usize = 5 * 1024 * 1024;
@@ -74,12 +115,21 @@ const MULTIPART_UPLOAD_CHUNK_SIZE_BYTES: usize = 5 * 1024 * 1024;
 /// Maximum number of concurrent downloads when getting snapshots from the repository.
 const DOWNLOAD_CONCURRENCY_LIMIT: usize = 8;
 
+fn is_false(value: &bool) -> bool {
+    !value
+}
+
 #[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum LatestSnapshotVersion {
     V1,
     /// V2 adds support for retained snapshots. Introduced in v1.6.
     #[default]
     V2,
+    /// V3 adds retention-protected snapshot references.
+    ///
+    /// Once a repository contains V3 metadata, older binaries fail to deserialize its pointer
+    /// and therefore cannot silently discard protection during a rolling downgrade.
+    V3,
 }
 
 #[serde_as]
@@ -88,7 +138,7 @@ pub struct LatestSnapshot {
     pub version: LatestSnapshotVersion,
 
     pub partition_id: PartitionId,
-    pub log_id: Option<LogId>, // mandatory in LatestSnapshotVersion::V2
+    pub log_id: Option<LogId>, // mandatory in LatestSnapshotVersion::V2 and V3
 
     /// Restate cluster name which produced the snapshot.
     pub cluster_name: String,
@@ -128,15 +178,19 @@ pub struct SnapshotReference {
     #[serde(with = "serde_with::As::<serde_with::DisplayFromStr>")]
     pub created_at: jiff::Timestamp,
     pub path: String,
+    /// Protected snapshots are excluded from automatic retention cleanup.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub protected: bool,
 }
 
 impl SnapshotReference {
-    fn from_metadata(snapshot: &PartitionSnapshotMetadata) -> Self {
+    fn from_metadata(snapshot: &PartitionSnapshotMetadata, protected: bool) -> Self {
         SnapshotReference {
             snapshot_id: snapshot.snapshot_id,
             min_applied_lsn: snapshot.min_applied_lsn,
             created_at: snapshot.created_at,
             path: UniqueSnapshotKey::from_metadata(snapshot).padded_key(),
+            protected,
         }
     }
 }
@@ -155,10 +209,17 @@ impl LatestSnapshot {
                     min_applied_lsn: self.min_applied_lsn,
                     created_at: self.created_at,
                     path: self.path.clone(),
+                    protected: false,
                 }]
             }
         } else {
-            self.retained_snapshots.clone()
+            let mut snapshots = self.retained_snapshots.clone();
+            if self.version != LatestSnapshotVersion::V3 {
+                for snapshot in &mut snapshots {
+                    snapshot.protected = false;
+                }
+            }
+            snapshots
         }
     }
 
@@ -197,7 +258,8 @@ impl LatestSnapshot {
 #[display("{}", latest_snapshot_id)]
 pub struct PartitionSnapshotStatus {
     // Field ordering is intentional to naturally order items by LSN
-    /// Safe to trim LSN for the partition
+    /// Safe log trim LSN based on ordinary rolling-retention snapshots. Protected backup
+    /// artifacts do not hold this back.
     pub archived_lsn: Lsn,
     pub latest_snapshot_lsn: Lsn,
     pub latest_snapshot_id: SnapshotId,
@@ -232,9 +294,10 @@ impl TryFrom<&LatestSnapshot> for PartitionSnapshotStatus {
                     .map(|p| p.log_id())
                     .unwrap_or_else(|| LogId::default_for_partition(latest.partition_id))
             }
-            (LatestSnapshotVersion::V2, None) => {
+            (LatestSnapshotVersion::V2 | LatestSnapshotVersion::V3, None) => {
                 return Err(anyhow!(
-                    "LatestSnapshot V2 for partition {} (snapshot {}) missing required log_id",
+                    "LatestSnapshot {:?} for partition {} (snapshot {}) missing required log_id",
+                    latest.version,
                     latest.partition_id,
                     latest.snapshot_id
                 ));
@@ -259,6 +322,26 @@ impl TryFrom<&LatestSnapshot> for PartitionSnapshotStatus {
                     .iter()
                     .max_by_key(|s| s.min_applied_lsn)
                     .map(|s| s.created_at.into())
+                    .unwrap_or_else(|| latest.created_at.into());
+
+                (archived_lsn, latest_snapshot_created_at)
+            }
+            LatestSnapshotVersion::V3 => {
+                // Protected backup artifacts are retained independently and do not hold back log
+                // trimming. Only ordinary rolling-retention snapshots define the trim-safe LSN.
+                let archived_lsn = latest
+                    .retained_snapshots
+                    .iter()
+                    .filter(|snapshot| !snapshot.protected)
+                    .min_by_key(|snapshot| snapshot.min_applied_lsn)
+                    .map(|snapshot| snapshot.min_applied_lsn)
+                    .unwrap_or(latest.min_applied_lsn);
+
+                let latest_snapshot_created_at = latest
+                    .retained_snapshots
+                    .iter()
+                    .max_by_key(|snapshot| snapshot.min_applied_lsn)
+                    .map(|snapshot| snapshot.created_at.into())
                     .unwrap_or_else(|| latest.created_at.into());
 
                 (archived_lsn, latest_snapshot_created_at)
@@ -300,6 +383,11 @@ impl UniqueSnapshotKey {
 }
 
 impl SnapshotRepository {
+    /// Returns the normalized repository destination used to address snapshot objects.
+    pub fn destination(&self) -> &Url {
+        &self.destination
+    }
+
     /// Creates an instance of the repository if a snapshots destination is configured.
     pub async fn new_from_config(
         snapshots_options: &SnapshotsOptions,
@@ -316,29 +404,58 @@ impl SnapshotRepository {
             .inspect(|params| info!("Snapshot destination parameters ignored: {params}"));
         destination.set_query(None);
 
-        let prefix = destination.path().to_string();
-        let object_store = create_object_store_client(
-            destination.clone(),
-            &snapshots_options.object_store,
-            &snapshots_options.object_store_retry_policy,
-        )
-        .await?;
+        Self::new_at_destination(snapshots_options, destination, staging_dir)
+            .await
+            .map(Some)
+    }
 
-        // Best-effort cleanup of leftover snapshot staging directories from a previous run
-        // (e.g. downloads interrupted by a hard crash mid-import, which the per-download RAII
-        // guard cannot clean up). Safe here because no downloads are in flight at startup.
-        // See https://github.com/restatedev/restate/issues/4838.
-        Self::sweep_staging_dir(&staging_dir).await;
+    /// Opens an explicit source repository using the configured object-store credentials and
+    /// retry policy without changing the node's active snapshot destination.
+    ///
+    /// Snapshot upload APIs are crate-private, so callers outside `partition-store` can only use
+    /// the returned repository for restore inspection and downloads.
+    pub async fn new_for_source(
+        snapshots_options: &SnapshotsOptions,
+        mut source_destination: Url,
+        staging_dir: PathBuf,
+    ) -> anyhow::Result<SnapshotRepository> {
+        source_destination
+            .query()
+            .inspect(|params| info!("Snapshot source parameters ignored: {params}"));
+        source_destination.set_query(None);
+        Self::new_at_destination(snapshots_options, source_destination, staging_dir).await
+    }
 
-        Ok(Some(SnapshotRepository {
-            object_store,
-            destination,
-            prefix: ObjectPath::from(prefix),
-            staging_dir,
-            num_retained: snapshots_options.num_retained,
-            #[cfg(any(test, feature = "test-util"))]
-            enable_cleanup: snapshots_options.enable_cleanup,
-        }))
+    fn new_at_destination(
+        snapshots_options: &SnapshotsOptions,
+        destination: Url,
+        staging_dir: PathBuf,
+    ) -> BoxFuture<'_, anyhow::Result<SnapshotRepository>> {
+        Box::pin(async move {
+            let prefix = destination.path().to_string();
+            let object_store = create_object_store_client(
+                destination.clone(),
+                &snapshots_options.object_store,
+                &snapshots_options.object_store_retry_policy,
+            )
+            .await?;
+
+            // Best-effort cleanup of leftover snapshot staging directories from a previous run
+            // (e.g. downloads interrupted by a hard crash mid-import, which the per-download RAII
+            // guard cannot clean up). Safe here because no downloads are in flight at startup.
+            // See https://github.com/restatedev/restate/issues/4838.
+            Self::sweep_staging_dir(&staging_dir).await;
+
+            Ok(SnapshotRepository {
+                object_store,
+                destination,
+                prefix: ObjectPath::from(prefix),
+                staging_dir,
+                num_retained: snapshots_options.num_retained,
+                #[cfg(any(test, feature = "test-util"))]
+                enable_cleanup: snapshots_options.enable_cleanup,
+            })
+        })
     }
 
     /// Removes any entries left over in the snapshot staging directory by a previous run.
@@ -380,6 +497,26 @@ impl SnapshotRepository {
         snapshot: &PartitionSnapshotMetadata,
         local_snapshot: SnapshotDir,
     ) -> anyhow::Result<PartitionSnapshotStatus> {
+        self.put_with_retention(snapshot, local_snapshot, false)
+            .await
+    }
+
+    /// Writes a snapshot which automatic rolling retention must not delete.
+    pub(crate) async fn put_protected(
+        &self,
+        snapshot: &PartitionSnapshotMetadata,
+        local_snapshot: SnapshotDir,
+    ) -> anyhow::Result<PartitionSnapshotStatus> {
+        self.put_with_retention(snapshot, local_snapshot, true)
+            .await
+    }
+
+    async fn put_with_retention(
+        &self,
+        snapshot: &PartitionSnapshotMetadata,
+        local_snapshot: SnapshotDir,
+        protect_from_retention: bool,
+    ) -> anyhow::Result<PartitionSnapshotStatus> {
         use crate::metric_definitions::{
             SNAPSHOT_UPLOAD_DURATION, SNAPSHOT_UPLOAD_FAILED, SNAPSHOT_UPLOAD_SUCCESS,
         };
@@ -388,7 +525,7 @@ impl SnapshotRepository {
 
         let start = tokio::time::Instant::now();
         let put_result = self
-            .put_snapshot_inner(snapshot, local_snapshot.path())
+            .put_snapshot_inner(snapshot, local_snapshot.path(), protect_from_retention)
             .await;
 
         // We own the local snapshot directory; remove it asynchronously (it may hold large SST
@@ -424,6 +561,7 @@ impl SnapshotRepository {
         &self,
         snapshot: &PartitionSnapshotMetadata,
         local_snapshot_path: &Path,
+        protect_from_retention: bool,
     ) -> Result<PartitionSnapshotStatus, PutSnapshotError> {
         let snapshot_prefix = self.base_prefix(snapshot);
         debug!(
@@ -444,8 +582,22 @@ impl SnapshotRepository {
             .map_err(|e| PutSnapshotError::from(e, progress.clone()))?;
 
         if let Some((latest_stored, _)) = &maybe_stored
-            && latest_stored.min_applied_lsn >= snapshot.min_applied_lsn
+            && (latest_stored.min_applied_lsn > snapshot.min_applied_lsn
+                || (!protect_from_retention
+                    && latest_stored.min_applied_lsn == snapshot.min_applied_lsn))
         {
+            if protect_from_retention {
+                return Err(PutSnapshotError::from(
+                    anyhow!(
+                        "cannot protect snapshot {} at LSN {} because repository latest is newer at LSN {}; retry after the partition catches up",
+                        snapshot.snapshot_id,
+                        snapshot.min_applied_lsn,
+                        latest_stored.min_applied_lsn,
+                    ),
+                    progress,
+                ));
+            }
+
             info!(
                 repository_latest_lsn = ?latest_stored.min_applied_lsn,
                 new_snapshot_lsn = ?snapshot.min_applied_lsn,
@@ -453,7 +605,7 @@ impl SnapshotRepository {
                 will not update latest pointer"
             );
 
-            let snapshot_ref = SnapshotReference::from_metadata(snapshot);
+            let snapshot_ref = SnapshotReference::from_metadata(snapshot, false);
             let partition_id = snapshot.partition_id;
             let repository = self.clone();
             let _ = restate_core::TaskCenter::spawn_unmanaged_child(
@@ -472,7 +624,11 @@ impl SnapshotRepository {
         }
 
         let (new_latest, evicted_snapshots) = self
-            .build_latest_v2(snapshot, maybe_stored.as_ref().map(|(l, _)| l))
+            .build_latest_pointer(
+                snapshot,
+                maybe_stored.as_ref().map(|(l, _)| l),
+                protect_from_retention,
+            )
             .map_err(|e| PutSnapshotError::from(e, progress.clone()))?;
 
         let latest_payload = PutPayload::from(
@@ -553,17 +709,18 @@ impl SnapshotRepository {
         Ok(())
     }
 
-    /// Builds V2 latest snapshot metadata.
+    /// Builds the latest snapshot pointer in the format required by its retained references.
     ///
     /// Returns `(LatestSnapshot, Vec<SnapshotReference>)` where the second element contains
     /// snapshots that no longer need to be retained following the metadata update.
     /// If cleanup fails, these snapshots will be orphaned until cleaned up by the sweeper.
-    fn build_latest_v2(
+    fn build_latest_pointer(
         &self,
         snapshot: &PartitionSnapshotMetadata,
         current: Option<&LatestSnapshot>,
+        protect_from_retention: bool,
     ) -> anyhow::Result<(LatestSnapshot, Vec<SnapshotReference>)> {
-        let new_snapshot_ref = SnapshotReference::from_metadata(snapshot);
+        let new_snapshot_ref = SnapshotReference::from_metadata(snapshot, protect_from_retention);
 
         let mut retained_snapshots = current
             .map(|l| l.effective_retained_snapshots())
@@ -572,11 +729,29 @@ impl SnapshotRepository {
         // List will be in correct descending order if we insert the newest snapshot first
         retained_snapshots.insert(0, new_snapshot_ref.clone());
 
-        let evicted_snapshots = retained_snapshots
-            .split_off((self.num_retained.get() as usize).min(retained_snapshots.len()));
+        let mut ordinary_retained = 0;
+        let mut evicted_snapshots = Vec::new();
+        retained_snapshots.retain(|snapshot| {
+            if snapshot.protected {
+                true
+            } else if ordinary_retained < self.num_retained.get() as usize {
+                ordinary_retained += 1;
+                true
+            } else {
+                evicted_snapshots.push(snapshot.clone());
+                false
+            }
+        });
 
+        let version = if protect_from_retention
+            || current.is_some_and(|latest| latest.version == LatestSnapshotVersion::V3)
+        {
+            LatestSnapshotVersion::V3
+        } else {
+            LatestSnapshotVersion::V2
+        };
         let latest = LatestSnapshot {
-            version: LatestSnapshotVersion::V2,
+            version,
             partition_id: snapshot.partition_id,
             log_id: Some(snapshot.log_id),
             cluster_name: snapshot.cluster_name.clone(),
@@ -702,7 +877,13 @@ impl SnapshotRepository {
         use crate::metric_definitions::{SNAPSHOT_DOWNLOAD_DURATION, SNAPSHOT_DOWNLOAD_FAILED};
 
         let start = tokio::time::Instant::now();
-        let result = self.get_latest_inner(partition_id).await;
+        let source = Metadata::with_current(|m| {
+            SnapshotSource::new(
+                m.nodes_config_ref().cluster_name().to_owned(),
+                m.nodes_config_ref().cluster_fingerprint(),
+            )
+        });
+        let result = self.get_latest_for_source(partition_id, &source).await;
 
         if result.is_err() {
             metrics::counter!(SNAPSHOT_DOWNLOAD_FAILED).increment(1);
@@ -712,10 +893,23 @@ impl SnapshotRepository {
         result
     }
 
-    async fn get_latest_inner(
+    async fn get_latest_for_source(
         &self,
         partition_id: PartitionId,
+        source: &SnapshotSource,
     ) -> anyhow::Result<Option<LocalPartitionSnapshot>> {
+        let Some(record) = self.resolve_latest_for_source(partition_id, source).await? else {
+            return Ok(None);
+        };
+        self.download_record(record).await.map(Some)
+    }
+
+    /// Resolve the mutable latest pointer once, returning a pinned immutable snapshot record.
+    pub async fn resolve_latest_for_source(
+        &self,
+        partition_id: PartitionId,
+        source: &SnapshotSource,
+    ) -> anyhow::Result<Option<SnapshotRecord>> {
         let latest_path = self.latest_snapshot_pointer_path(partition_id);
 
         let latest = match self.object_store.get(&latest_path).await {
@@ -730,22 +924,58 @@ impl SnapshotRepository {
         let latest: LatestSnapshot = serde_json::from_slice(&latest.bytes().await?)?;
         tracing::Span::current().record("snapshot_id", tracing::field::display(latest.snapshot_id));
         debug!("Latest snapshot metadata: {latest:?}");
-        Metadata::with_current(|m| {
-            let nodes_config = m.nodes_config_ref();
+        source
+            .validate_latest(&latest)
+            .with_context(|| format!("'{latest_path}' has validation errors"))?;
 
-            latest.validate(
-                nodes_config.cluster_name(),
-                nodes_config.cluster_fingerprint(),
-            )?;
-            anyhow::Ok(())
-        })
-        .with_context(|| format!("'{latest_path}' has validation errors"))?;
+        if latest.partition_id != partition_id {
+            bail!(
+                "Latest snapshot at '{latest_path}' has partition {}, expected {partition_id}",
+                latest.partition_id
+            );
+        }
 
+        self.inspect_snapshot(
+            partition_id,
+            latest.snapshot_id,
+            latest.min_applied_lsn,
+            latest.path.as_str(),
+            source,
+        )
+        .await
+        .map(Some)
+    }
+
+    /// Inspect an exact immutable snapshot without downloading its SSTs.
+    pub async fn inspect_exact(
+        &self,
+        partition_id: PartitionId,
+        snapshot_id: SnapshotId,
+        min_applied_lsn: Lsn,
+        source: &SnapshotSource,
+    ) -> anyhow::Result<SnapshotRecord> {
+        let path = UniqueSnapshotKey {
+            snapshot_id,
+            lsn: min_applied_lsn,
+        }
+        .padded_key();
+        self.inspect_snapshot(partition_id, snapshot_id, min_applied_lsn, &path, source)
+            .await
+    }
+
+    async fn inspect_snapshot(
+        &self,
+        partition_id: PartitionId,
+        expected_snapshot_id: SnapshotId,
+        expected_min_applied_lsn: Lsn,
+        snapshot_path: &str,
+        source: &SnapshotSource,
+    ) -> anyhow::Result<SnapshotRecord> {
         let snapshot_metadata_path = self
             .prefix
             .clone()
             .join(partition_id.to_string())
-            .join(latest.path.as_str())
+            .join(snapshot_path)
             .join("metadata.json");
         let snapshot_metadata = self.object_store.get(&snapshot_metadata_path).await;
 
@@ -759,7 +989,7 @@ impl SnapshotRepository {
             Err(err) => return Err(err.into()),
         };
 
-        let mut snapshot_metadata: PartitionSnapshotMetadata =
+        let snapshot_metadata: PartitionSnapshotMetadata =
             serde_json::from_slice(&snapshot_metadata.bytes().await?)?;
         if !matches!(snapshot_metadata.version, SnapshotFormatVersion::V1) {
             bail!(
@@ -768,21 +998,54 @@ impl SnapshotRepository {
             );
         }
 
-        Metadata::with_current(|m| {
-            let nodes_config = m.nodes_config_ref();
+        source
+            .validate_metadata(&snapshot_metadata)
+            .with_context(|| {
+                format!(
+                    "failed validating metadata of snapshot {}",
+                    snapshot_metadata.snapshot_id
+                )
+            })?;
 
-            snapshot_metadata.validate(
-                nodes_config.cluster_name(),
-                nodes_config.cluster_fingerprint(),
-            )?;
-            anyhow::Ok(())
+        if snapshot_metadata.partition_id != partition_id
+            || snapshot_metadata.snapshot_id != expected_snapshot_id
+            || snapshot_metadata.min_applied_lsn != expected_min_applied_lsn
+        {
+            bail!(
+                "snapshot metadata at '{snapshot_metadata_path}' does not match requested immutable identity: expected partition {partition_id}, snapshot {expected_snapshot_id}, minimum applied LSN {expected_min_applied_lsn}; got partition {}, snapshot {}, minimum applied LSN {}",
+                snapshot_metadata.partition_id,
+                snapshot_metadata.snapshot_id,
+                snapshot_metadata.min_applied_lsn,
+            );
+        }
+
+        Ok(SnapshotRecord {
+            partition_id,
+            snapshot_id: expected_snapshot_id,
+            min_applied_lsn: expected_min_applied_lsn,
+            metadata: snapshot_metadata,
+            path: snapshot_path.to_owned(),
         })
-        .with_context(|| {
-            format!(
-                "failed validating metadata of snapshot {}",
-                snapshot_metadata.snapshot_id
-            )
-        })?;
+    }
+
+    /// Download SSTs for a record previously pinned by [`Self::inspect_exact`] or
+    /// [`Self::resolve_latest_for_source`].
+    pub async fn download_record(
+        &self,
+        record: SnapshotRecord,
+    ) -> anyhow::Result<LocalPartitionSnapshot> {
+        let partition_id = record.partition_id;
+        let snapshot_path = record.path;
+        let mut snapshot_metadata = record.metadata;
+
+        // Validate every untrusted metadata entry before creating a staging directory or fetching
+        // any snapshot component. This also prevents a later entry from escaping the staging
+        // directory after earlier entries have already been downloaded.
+        let filenames = snapshot_metadata
+            .files
+            .iter()
+            .map(|file| snapshot_file_basename(&file.name).map(str::to_owned))
+            .collect::<anyhow::Result<Vec<_>>>()?;
 
         if !self.staging_dir.exists() {
             std::fs::create_dir_all(&self.staging_dir)?;
@@ -800,22 +1063,21 @@ impl SnapshotRepository {
         let concurrency_limiter = Arc::new(Semaphore::new(DOWNLOAD_CONCURRENCY_LIMIT));
         let mut downloads = JoinSet::new();
         let mut task_handles = HashMap::with_capacity(snapshot_metadata.files.len());
-        for file in &mut snapshot_metadata.files {
-            let filename = strip_leading_slash(&file.name);
+        for (file, filename) in snapshot_metadata.files.iter_mut().zip(filenames) {
             let expected_size = file.size;
             let key = self
                 .prefix
                 .clone()
                 .join(partition_id.to_string())
-                .join(latest.path.as_str())
-                .join(filename);
-            let local_path = snapshot_dir.path().join(filename);
+                .join(snapshot_path.as_str())
+                .join(filename.as_str());
+            let local_path = snapshot_dir.path().join(&filename);
             let concurrency_limiter = Arc::clone(&concurrency_limiter);
             let object_store = Arc::clone(&self.object_store);
             let snapshot_id = snapshot_metadata.snapshot_id;
-            let snapshot_filename = filename.to_owned();
+            let snapshot_filename = filename.clone();
 
-            let handle = downloads.build_task().name(filename).spawn(async move {
+            let handle = downloads.build_task().name(&filename).spawn(async move {
                 let _permit = concurrency_limiter.acquire().await?;
                 debug!(%key, "Downloading snapshot object");
                 let mut file_data = StreamReader::new(
@@ -846,7 +1108,7 @@ impl SnapshotRepository {
                 );
                 anyhow::Ok(())
             }.instrument(Span::current()))?;
-            task_handles.insert(handle.id(), filename.to_string());
+            task_handles.insert(handle.id(), filename);
             // patch the directory path to reflect the actual location on the restoring node
             file.directory.clone_from(&directory);
         }
@@ -882,20 +1144,20 @@ impl SnapshotRepository {
         // Transfer ownership of the staging directory from the `TempDir` (which auto-cleans on
         // an early return mid-download) to the snapshot's `SnapshotDir`, which removes it on drop
         // whether the subsequent import succeeds or fails (see #4838).
-        Ok(Some(LocalPartitionSnapshot {
+        Ok(LocalPartitionSnapshot {
             base_dir: SnapshotDir::new(snapshot_dir.keep()),
             log_id: snapshot_metadata.log_id,
             min_applied_lsn: snapshot_metadata.min_applied_lsn,
             db_comparator_name: snapshot_metadata.db_comparator_name,
             files: snapshot_metadata.files,
             key_range: snapshot_metadata.key_range,
-        }))
+        })
     }
 
     /// Retrieve the latest snapshot metadata from the snapshot repository
     ///
-    /// If there are multiple retained snapshots, the archived LSN will be that of the earliest
-    /// snapshot's LSN. This allows restoring any of the retained snapshots.
+    /// If there are multiple ordinary retained snapshots, the archived LSN will be the earliest
+    /// ordinary snapshot's LSN. Protected backups survive cleanup but do not hold back log trims.
     pub async fn get_latest_partition_snapshot_status(
         &self,
         partition_id: PartitionId,
@@ -1009,6 +1271,24 @@ impl SnapshotRepository {
 // Strip the leading "/" character from RocksDB LiveFile names
 fn strip_leading_slash(name: &str) -> &str {
     name.trim_start_matches('/')
+}
+
+/// Returns the local basename represented by a RocksDB live-file name.
+///
+/// RocksDB prefixes live-file names with one `/`. Apart from that format convention, snapshot
+/// components must be a single non-empty basename so repository metadata cannot address files
+/// outside the download staging directory.
+fn snapshot_file_basename(name: &str) -> anyhow::Result<&str> {
+    let basename = name.strip_prefix('/').unwrap_or(name);
+    if basename.is_empty()
+        || basename == "."
+        || basename == ".."
+        || basename.contains('/')
+        || basename.contains('\\')
+    {
+        bail!("invalid snapshot component filename {name:?}: expected a single basename");
+    }
+    Ok(basename)
 }
 
 #[derive(Clone, Debug)]
@@ -1140,8 +1420,77 @@ mod tests {
 
     use crate::snapshots::repository::{LatestSnapshotVersion, SnapshotUploadProgress};
 
-    use super::{LatestSnapshot, SnapshotReference, SnapshotRepository, UniqueSnapshotKey};
+    use super::{
+        LatestSnapshot, PartitionSnapshotStatus, SnapshotRecord, SnapshotReference,
+        SnapshotRepository, SnapshotSource, UniqueSnapshotKey, snapshot_file_basename,
+    };
     use super::{PartitionSnapshotMetadata, SnapshotDir, SnapshotFormatVersion};
+
+    #[test]
+    fn snapshot_component_filename_must_be_a_basename() {
+        assert_eq!(snapshot_file_basename("000123.sst").unwrap(), "000123.sst");
+        assert_eq!(snapshot_file_basename("/000123.sst").unwrap(), "000123.sst");
+
+        for invalid in [
+            "",
+            "/",
+            ".",
+            "..",
+            "../escaped.sst",
+            "nested/data.sst",
+            "/tmp/data.sst",
+            "//data.sst",
+            r"nested\data.sst",
+            r"C:\data.sst",
+        ] {
+            assert!(
+                snapshot_file_basename(invalid).is_err(),
+                "accepted invalid snapshot component filename {invalid:?}"
+            );
+        }
+    }
+
+    #[restate_core::test]
+    async fn invalid_snapshot_component_is_rejected_before_staging() -> anyhow::Result<()> {
+        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let test_dir = TempDir::new()?;
+        let repository_dir = test_dir.path().join("repository");
+        tokio::fs::create_dir(&repository_dir).await?;
+        let staging_dir = test_dir.path().join("staging");
+        let escaped_path = test_dir.path().join("escaped.sst");
+        let repository = SnapshotRepository::new_from_config(
+            &SnapshotsOptions {
+                destination: Some(Url::from_file_path(&repository_dir).unwrap().to_string()),
+                ..SnapshotsOptions::default()
+            },
+            staging_dir.clone(),
+        )
+        .await?
+        .unwrap();
+
+        let metadata = mock_snapshot_metadata(
+            "../../escaped.sst".to_owned(),
+            "untrusted-directory".to_owned(),
+            0,
+        );
+        let record = SnapshotRecord {
+            partition_id: metadata.partition_id,
+            snapshot_id: metadata.snapshot_id,
+            min_applied_lsn: metadata.min_applied_lsn,
+            metadata,
+            path: "snapshot".to_owned(),
+        };
+
+        let error = repository.download_record(record).await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("invalid snapshot component filename")
+        );
+        assert!(!tokio::fs::try_exists(&staging_dir).await?);
+        assert!(!tokio::fs::try_exists(&escaped_path).await?);
+        Ok(())
+    }
 
     #[restate_core::test]
     async fn overwrite_unparsable_latest() -> anyhow::Result<()> {
@@ -1204,6 +1553,115 @@ mod tests {
                 .to_string(),
         )
         .await
+    }
+
+    #[restate_core::test]
+    async fn inspect_and_download_exact_snapshot_for_explicit_source() -> anyhow::Result<()> {
+        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+
+        let destination = TempDir::new()?;
+        let repository = SnapshotRepository::new_from_config(
+            &SnapshotsOptions {
+                destination: Some(Url::from_file_path(destination.path()).unwrap().to_string()),
+                ..SnapshotsOptions::default()
+            },
+            TempDir::new()?.keep(),
+        )
+        .await?
+        .unwrap();
+
+        let source_dir = TempDir::new()?.keep();
+        let data = b"snapshot-data";
+        tokio::fs::write(source_dir.join("data.sst"), data).await?;
+        let snapshot = mock_snapshot_metadata(
+            "/data.sst".to_owned(),
+            source_dir.to_string_lossy().to_string(),
+            data.len(),
+        );
+        let source =
+            SnapshotSource::new(snapshot.cluster_name.clone(), snapshot.cluster_fingerprint);
+        repository
+            .put(&snapshot, SnapshotDir::new(source_dir))
+            .await?;
+
+        let record = repository
+            .resolve_latest_for_source(snapshot.partition_id, &source)
+            .await?
+            .expect("latest snapshot exists");
+        assert_eq!(record.snapshot_id, snapshot.snapshot_id);
+        assert_eq!(record.min_applied_lsn, snapshot.min_applied_lsn);
+        assert_eq!(record.metadata.key_range, snapshot.key_range);
+        assert_eq!(record.metadata.log_id, snapshot.log_id);
+        assert_eq!(record.metadata.files.len(), 1);
+
+        let downloaded = repository.download_record(record).await?;
+        assert_eq!(downloaded.min_applied_lsn, snapshot.min_applied_lsn);
+        assert_eq!(downloaded.log_id, snapshot.log_id);
+
+        let wrong_source = SnapshotSource::new("different-cluster".to_owned(), None);
+        assert!(
+            repository
+                .resolve_latest_for_source(snapshot.partition_id, &wrong_source)
+                .await
+                .is_err()
+        );
+        assert!(
+            repository
+                .inspect_exact(
+                    snapshot.partition_id,
+                    SnapshotId::new(),
+                    snapshot.min_applied_lsn,
+                    &source,
+                )
+                .await
+                .is_err()
+        );
+        assert!(
+            repository
+                .inspect_exact(
+                    snapshot.partition_id,
+                    snapshot.snapshot_id,
+                    snapshot.min_applied_lsn.next(),
+                    &source,
+                )
+                .await
+                .is_err()
+        );
+
+        Ok(())
+    }
+
+    #[restate_core::test]
+    async fn source_repository_uses_explicit_destination_without_changing_active_options()
+    -> anyhow::Result<()> {
+        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+        let active = TempDir::new()?;
+        let source = TempDir::new()?;
+        let active_destination = Url::from_file_path(active.path()).unwrap().to_string();
+        let mut source_destination = Url::from_file_path(source.path()).unwrap();
+        source_destination.set_query(Some("ignored=true"));
+        let options = SnapshotsOptions {
+            destination: Some(active_destination.clone()),
+            ..SnapshotsOptions::default()
+        };
+
+        let repository = SnapshotRepository::new_for_source(
+            &options,
+            source_destination,
+            TempDir::new()?.keep(),
+        )
+        .await?;
+
+        assert_eq!(repository.destination().query(), None);
+        assert_eq!(
+            repository.destination().path(),
+            source.path().to_str().unwrap()
+        );
+        assert_eq!(
+            options.destination.as_deref(),
+            Some(active_destination.as_str())
+        );
+        Ok(())
     }
 
     /// For this test to run, set RESTATE_S3_INTEGRATION_TEST_BUCKET_NAME to a writable S3 bucket name
@@ -1288,7 +1746,7 @@ mod tests {
             .get(&partition_prefix.clone().join("latest.json"))
             .await?;
         let latest: LatestSnapshot = serde_json::from_slice(&latest.bytes().await?)?;
-        let (expected_latest, _) = repository.build_latest_v2(&snapshot1, None)?;
+        let (expected_latest, _) = repository.build_latest_pointer(&snapshot1, None, false)?;
         assert_eq!(expected_latest, latest);
 
         let snapshot_source = TempDir::new()?;
@@ -1314,7 +1772,7 @@ mod tests {
             .get(&partition_prefix.join("latest.json"))
             .await?;
         let latest: LatestSnapshot = serde_json::from_slice(&latest.bytes().await?)?;
-        let (expected_latest2, _) = repository.build_latest_v2(&snapshot2, None)?;
+        let (expected_latest2, _) = repository.build_latest_pointer(&snapshot2, None, false)?;
         assert_eq!(expected_latest2, latest);
 
         let latest = repository.get_latest(PartitionId::MIN).await?.unwrap();
@@ -1448,6 +1906,100 @@ mod tests {
         assert_eq!(latest.retained_snapshots[0].min_applied_lsn, Lsn::new(4000));
         assert_eq!(latest.retained_snapshots[1].min_applied_lsn, Lsn::new(3000));
         assert_eq!(latest.retained_snapshots[2].min_applied_lsn, Lsn::new(2000));
+
+        let status = PartitionSnapshotStatus::try_from(&latest)?;
+        assert_eq!(status.latest_snapshot_id, latest.snapshot_id);
+        assert_eq!(status.latest_snapshot_lsn, Lsn::new(4000));
+        assert_eq!(status.archived_lsn, Lsn::new(2000));
+
+        Ok(())
+    }
+
+    #[restate_core::test]
+    async fn protected_snapshot_survives_cleanup_without_holding_back_trim_lsn()
+    -> anyhow::Result<()> {
+        let _env = TestCoreEnv::create_with_single_node(1, 1).await;
+
+        let snapshots_destination = TempDir::new()?;
+        let destination = Url::from_file_path(snapshots_destination.path())
+            .unwrap()
+            .to_string();
+        let repository = SnapshotRepository::new_from_config(
+            &SnapshotsOptions {
+                destination: Some(destination),
+                num_retained: std::num::NonZeroU8::new(1).unwrap(),
+                enable_cleanup: true,
+                ..SnapshotsOptions::default()
+            },
+            TempDir::new()?.keep(),
+        )
+        .await?
+        .unwrap();
+
+        let (protected, protected_dir) = mock_snapshot(b"protected", Lsn::new(100)).await?;
+        let protected_ref = SnapshotReference::from_metadata(&protected, true);
+        repository
+            .put_protected(&protected, SnapshotDir::new(protected_dir))
+            .await?;
+
+        let (evicted, evicted_dir) = mock_snapshot(b"evicted", Lsn::new(200)).await?;
+        let evicted_ref = SnapshotReference::from_metadata(&evicted, false);
+        repository
+            .put(&evicted, SnapshotDir::new(evicted_dir))
+            .await?;
+
+        let (latest_snapshot, latest_dir) = mock_snapshot(b"latest", Lsn::new(300)).await?;
+        repository
+            .put(&latest_snapshot, SnapshotDir::new(latest_dir))
+            .await?;
+
+        let latest = repository
+            .get_latest_snapshot_metadata_for_update(
+                &repository.latest_snapshot_pointer_path(PartitionId::MIN),
+            )
+            .await?
+            .map(|(latest, _)| latest)
+            .expect("latest metadata exists");
+        assert_eq!(latest.version, LatestSnapshotVersion::V3);
+        assert_eq!(latest.retained_snapshots.len(), 2);
+        assert!(
+            latest
+                .retained_snapshots
+                .iter()
+                .any(|snapshot| snapshot.snapshot_id == protected.snapshot_id && snapshot.protected)
+        );
+        let status = PartitionSnapshotStatus::try_from(&latest)?;
+        assert_eq!(status.latest_snapshot_lsn, Lsn::new(300));
+        assert_eq!(status.archived_lsn, Lsn::new(300));
+
+        let protected_metadata = repository
+            .partition_snapshots_prefix(PartitionId::MIN)
+            .join(protected_ref.path.as_str())
+            .join("metadata.json");
+        let evicted_metadata = repository
+            .partition_snapshots_prefix(PartitionId::MIN)
+            .join(evicted_ref.path.as_str())
+            .join("metadata.json");
+        for _ in 0..20 {
+            if matches!(
+                repository.object_store.get(&evicted_metadata).await,
+                Err(object_store::Error::NotFound { .. })
+            ) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(
+            repository
+                .object_store
+                .get(&protected_metadata)
+                .await
+                .is_ok()
+        );
+        assert!(matches!(
+            repository.object_store.get(&evicted_metadata).await,
+            Err(object_store::Error::NotFound { .. })
+        ));
 
         Ok(())
     }
@@ -1624,7 +2176,7 @@ mod tests {
         for i in 1..=5 {
             let (snapshot, source_dir) =
                 mock_snapshot(format!("data-{}", i).as_bytes(), Lsn::new(100 * i)).await?;
-            all_snapshot_paths.push(SnapshotReference::from_metadata(&snapshot).path);
+            all_snapshot_paths.push(SnapshotReference::from_metadata(&snapshot, false).path);
             repository
                 .put(&snapshot, SnapshotDir::new(source_dir))
                 .await?;
@@ -1696,8 +2248,8 @@ mod tests {
 
         // Create a V2 latest snapshot with multiple retained snapshots.
         // The retained_snapshots list is intentionally out of order to verify that the
-        // conversion code does NOT rely on the descending LSN sort invariant. This tests
-        // defensive behavior against corrupted or manually edited metadata.
+        // conversion code does NOT rely on the descending LSN sort invariant. V2 predates
+        // protection, so even a manually-added protected marker must not change its trim floor.
         let latest = LatestSnapshot {
             version: LatestSnapshotVersion::V2,
             partition_id: PartitionId::MIN,
@@ -1715,18 +2267,21 @@ mod tests {
                     min_applied_lsn: Lsn::new(3484), // Newest (index 0)
                     created_at: Timestamp::from_second(2).unwrap(),
                     path: "snap1".to_string(),
+                    protected: false,
                 },
                 SnapshotReference {
                     snapshot_id: SnapshotId::new(),
                     min_applied_lsn: Lsn::new(1342), // Oldest by LSN but at index 1
                     created_at: Timestamp::from_second(0).unwrap(),
                     path: "snap3".to_string(),
+                    protected: true,
                 },
                 SnapshotReference {
                     snapshot_id: SnapshotId::new(),
                     min_applied_lsn: Lsn::new(2839), // Middle LSN at index 2
                     created_at: Timestamp::from_second(1).unwrap(),
                     path: "snap2".to_string(),
+                    protected: false,
                 },
             ],
         };

--- a/crates/partition-store/src/snapshots/snapshot_task.rs
+++ b/crates/partition-store/src/snapshots/snapshot_task.rs
@@ -37,6 +37,7 @@ pub struct SnapshotPartitionTask {
     pub cluster_fingerprint: Option<ClusterFingerprint>,
     pub node_name: String,
     pub snapshot_repository: SnapshotRepository,
+    pub protect_from_retention: bool,
 }
 
 impl SnapshotPartitionTask {
@@ -86,15 +87,20 @@ impl SnapshotPartitionTask {
 
         let metadata = self.metadata(&snapshot, WallClock::recent_ms());
 
-        let status = self
-            .snapshot_repository
-            // `put` takes ownership of the snapshot directory and removes it after upload.
-            .put(&metadata, snapshot.base_dir)
-            .await
-            .map_err(|e| SnapshotError {
-                partition_id: self.partition_id,
-                kind: SnapshotErrorKind::RepositoryIo(e),
-            })?;
+        // The repository takes ownership of the snapshot directory and removes it after upload.
+        let status = if self.protect_from_retention {
+            self.snapshot_repository
+                .put_protected(&metadata, snapshot.base_dir)
+                .await
+        } else {
+            self.snapshot_repository
+                .put(&metadata, snapshot.base_dir)
+                .await
+        }
+        .map_err(|e| SnapshotError {
+            partition_id: self.partition_id,
+            kind: SnapshotErrorKind::RepositoryIo(e),
+        })?;
 
         if let Some(db) = self
             .partition_store_manager

--- a/crates/types/src/cluster_backup.rs
+++ b/crates/types/src/cluster_backup.rs
@@ -1,0 +1,295 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Portable descriptions of cluster backup artifacts.
+
+use std::collections::BTreeSet;
+
+use enumset::EnumSet;
+use serde::{Deserialize, Serialize};
+
+use crate::identifiers::{PartitionId, SnapshotId};
+use crate::logs::{LogId, Lsn};
+use crate::nodes_config::{ClusterFeature, ClusterFingerprint};
+use crate::partition_table::PartitionTable;
+use crate::schema::Schema;
+use crate::sharding::KeyRange;
+use crate::time::MillisSinceEpoch;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum BackupConsistency {
+    /// Metadata and partition artifacts were captured independently while the cluster was live.
+    BestEffort,
+}
+
+/// The kind of descriptor validated by [`ClusterBackupDescriptor::validate`].
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum BackupArtifactSet {
+    /// The descriptor records topology only. Restore resolves the server-side latest artifacts.
+    TopologyOnly,
+    /// The descriptor names one exact artifact for every captured partition.
+    Complete,
+    /// The backup attempt failed after recording only a valid subset of its artifacts.
+    Incomplete,
+}
+
+#[derive(Debug, thiserror::Error, Eq, PartialEq)]
+pub enum ClusterBackupDescriptorError {
+    #[error("unsupported cluster backup descriptor version {0}")]
+    UnsupportedVersion(u16),
+    #[error("source snapshot repository must not be empty")]
+    EmptySnapshotRepository,
+    #[error("source cluster name must not be empty")]
+    EmptyClusterName,
+    #[error("captured partition table must not be empty")]
+    EmptyPartitionTable,
+    #[error("backup descriptor has duplicate artifact for partition {0}")]
+    DuplicatePartition(PartitionId),
+    #[error("backup descriptor artifact set does not match the captured partition table")]
+    ArtifactSetMismatch,
+    #[error(
+        "backup descriptor artifact for partition {partition_id} does not match the captured topology"
+    )]
+    ArtifactTopologyMismatch { partition_id: PartitionId },
+}
+
+/// A versioned description of one V0 cluster backup attempt.
+///
+/// `artifacts` is absent for topology-only recovery of snapshots that existed before descriptor
+/// capture. A failed capture may contain a valid subset plus entries in `failures`; such a
+/// descriptor remains inspectable but is not restorable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClusterBackupDescriptor {
+    pub version: u16,
+    pub created_at: MillisSinceEpoch,
+    pub consistency: BackupConsistency,
+    /// Snapshot repository URL with query parameters removed, matching server-side normalization.
+    pub source_snapshot_repository: String,
+    pub source_cluster_name: String,
+    pub source_cluster_fingerprint: Option<ClusterFingerprint>,
+    /// Cluster-wide behavioral features that affect the interpretation and sharding of data.
+    pub source_cluster_features: EnumSet<ClusterFeature>,
+    pub partition_table: PartitionTable,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub schema: Option<Schema>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub artifacts: Option<Vec<PartitionBackupArtifact>>,
+    /// Failures observed while creating an exact artifact set. A non-empty value makes the
+    /// descriptor incomplete and therefore unsuitable for restore.
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub failures: Vec<PartitionBackupFailure>,
+}
+
+impl ClusterBackupDescriptor {
+    pub const VERSION: u16 = 1;
+
+    pub fn validate(&self) -> Result<BackupArtifactSet, ClusterBackupDescriptorError> {
+        if self.version != Self::VERSION {
+            return Err(ClusterBackupDescriptorError::UnsupportedVersion(
+                self.version,
+            ));
+        }
+        if self.source_snapshot_repository.is_empty() {
+            return Err(ClusterBackupDescriptorError::EmptySnapshotRepository);
+        }
+        if self.source_cluster_name.is_empty() {
+            return Err(ClusterBackupDescriptorError::EmptyClusterName);
+        }
+        if self.partition_table.is_empty() {
+            return Err(ClusterBackupDescriptorError::EmptyPartitionTable);
+        }
+
+        let Some(artifacts) = &self.artifacts else {
+            return Ok(if self.failures.is_empty() {
+                BackupArtifactSet::TopologyOnly
+            } else {
+                BackupArtifactSet::Incomplete
+            });
+        };
+
+        let expected = self
+            .partition_table
+            .iter_ids()
+            .copied()
+            .collect::<BTreeSet<_>>();
+        let mut actual = BTreeSet::new();
+        for artifact in artifacts {
+            if !actual.insert(artifact.partition_id) {
+                return Err(ClusterBackupDescriptorError::DuplicatePartition(
+                    artifact.partition_id,
+                ));
+            }
+            let Some(partition) = self.partition_table.get(&artifact.partition_id) else {
+                return Err(ClusterBackupDescriptorError::ArtifactSetMismatch);
+            };
+            if partition.log_id() != artifact.log_id || partition.key_range != artifact.key_range {
+                return Err(ClusterBackupDescriptorError::ArtifactTopologyMismatch {
+                    partition_id: artifact.partition_id,
+                });
+            }
+        }
+        if actual == expected && self.failures.is_empty() {
+            return Ok(BackupArtifactSet::Complete);
+        }
+        Ok(BackupArtifactSet::Incomplete)
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PartitionBackupArtifact {
+    pub partition_id: PartitionId,
+    pub snapshot_id: SnapshotId,
+    pub log_id: LogId,
+    pub min_applied_lsn: Lsn,
+    pub key_range: KeyRange,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct PartitionBackupFailure {
+    pub partition_id: PartitionId,
+    pub message: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use enumset::EnumSet;
+
+    use crate::Version;
+    use crate::identifiers::{PartitionId, SnapshotId};
+    use crate::logs::{LogId, Lsn};
+    use crate::partition_table::PartitionTable;
+    use crate::time::MillisSinceEpoch;
+
+    use super::{
+        BackupArtifactSet, BackupConsistency, ClusterBackupDescriptor,
+        ClusterBackupDescriptorError, PartitionBackupArtifact,
+    };
+
+    fn descriptor(artifacts: Option<Vec<PartitionBackupArtifact>>) -> ClusterBackupDescriptor {
+        let partition_table = PartitionTable::with_equally_sized_partitions(Version::MIN, 2);
+        ClusterBackupDescriptor {
+            version: ClusterBackupDescriptor::VERSION,
+            created_at: MillisSinceEpoch::new(1),
+            consistency: BackupConsistency::BestEffort,
+            source_snapshot_repository: "s3://bucket/backups".to_owned(),
+            source_cluster_name: "source".to_owned(),
+            source_cluster_fingerprint: None,
+            source_cluster_features: EnumSet::empty(),
+            partition_table,
+            schema: None,
+            artifacts,
+            failures: vec![],
+        }
+    }
+
+    fn artifact(partition_id: u16) -> PartitionBackupArtifact {
+        let partition_id = PartitionId::new_unchecked(partition_id);
+        PartitionBackupArtifact {
+            partition_id,
+            snapshot_id: SnapshotId::new(),
+            log_id: LogId::default_for_partition(partition_id),
+            min_applied_lsn: Lsn::new(1),
+            key_range: crate::sharding::KeyRange::new(0, 0),
+        }
+    }
+
+    #[test]
+    fn topology_only_roundtrips() {
+        let descriptor = descriptor(None);
+        let json = serde_json::to_string(&descriptor).unwrap();
+        let decoded: ClusterBackupDescriptor = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(decoded.validate(), Ok(BackupArtifactSet::TopologyOnly));
+        assert!(decoded.artifacts.is_none());
+    }
+
+    #[test]
+    fn cluster_features_are_required_in_v1() {
+        let mut value = serde_json::to_value(descriptor(None)).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .remove("source_cluster_features");
+
+        assert!(serde_json::from_value::<ClusterBackupDescriptor>(value).is_err());
+    }
+
+    #[test]
+    fn optional_schema_roundtrips() {
+        let mut descriptor = descriptor(None);
+        descriptor.schema = Some(Default::default());
+
+        let json = serde_json::to_string(&descriptor).unwrap();
+        let decoded: ClusterBackupDescriptor = serde_json::from_str(&json).unwrap();
+
+        assert!(decoded.schema.is_some());
+        assert_eq!(decoded.validate(), Ok(BackupArtifactSet::TopologyOnly));
+    }
+
+    #[test]
+    fn exact_artifacts_must_cover_the_captured_topology() {
+        let mut descriptor = descriptor(Some(vec![artifact(0)]));
+        assert_eq!(
+            descriptor.validate(),
+            Err(ClusterBackupDescriptorError::ArtifactTopologyMismatch {
+                partition_id: PartitionId::new_unchecked(0),
+            })
+        );
+
+        let artifacts = descriptor
+            .partition_table
+            .iter()
+            .map(|(id, partition)| PartitionBackupArtifact {
+                partition_id: *id,
+                snapshot_id: SnapshotId::new(),
+                log_id: partition.log_id(),
+                min_applied_lsn: Lsn::new(1),
+                key_range: partition.key_range,
+            })
+            .collect();
+        descriptor.artifacts = Some(artifacts);
+        assert_eq!(descriptor.validate(), Ok(BackupArtifactSet::Complete));
+    }
+
+    #[test]
+    fn duplicate_artifacts_are_rejected() {
+        let mut descriptor = descriptor(Some(vec![artifact(0), artifact(0)]));
+        let partition = descriptor
+            .partition_table
+            .get(&PartitionId::new_unchecked(0))
+            .unwrap();
+        for artifact in descriptor.artifacts.as_mut().unwrap() {
+            artifact.log_id = partition.log_id();
+            artifact.key_range = partition.key_range;
+        }
+
+        assert_eq!(
+            descriptor.validate(),
+            Err(ClusterBackupDescriptorError::DuplicatePartition(
+                PartitionId::new_unchecked(0)
+            ))
+        );
+    }
+
+    #[test]
+    fn partial_artifacts_are_inspectable_but_incomplete() {
+        let mut descriptor = descriptor(Some(vec![artifact(0)]));
+        let partition = descriptor
+            .partition_table
+            .get(&PartitionId::new_unchecked(0))
+            .unwrap();
+        let artifact = descriptor.artifacts.as_mut().unwrap().first_mut().unwrap();
+        artifact.log_id = partition.log_id();
+        artifact.key_range = partition.key_range;
+
+        assert_eq!(descriptor.validate(), Ok(BackupArtifactSet::Incomplete));
+    }
+}

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -22,6 +22,7 @@ mod version;
 
 pub mod art;
 pub mod cluster;
+pub mod cluster_backup;
 
 pub mod cluster_state;
 pub mod health;

--- a/crates/types/src/net/partition_processor_manager.rs
+++ b/crates/types/src/net/partition_processor_manager.rs
@@ -12,11 +12,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::Version;
 use crate::identifiers::{PartitionId, SnapshotId};
-use crate::logs::{LogId, Lsn};
+use crate::logs::{LogId, Lsn, SequenceNumber};
 use crate::net::{ServiceTag, define_service, define_unary_message};
 use crate::net::{default_wire_codec, define_rpc};
 
 pub struct PartitionManagerService;
+
+fn invalid_lsn() -> Lsn {
+    Lsn::INVALID
+}
 
 define_service! {
     @service = PartitionManagerService,
@@ -75,6 +79,8 @@ default_wire_codec!(CreateSnapshotResponse);
 pub struct CreateSnapshotRequest {
     pub partition_id: PartitionId,
     pub min_target_lsn: Option<Lsn>,
+    #[serde(default)]
+    pub protect_from_retention: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -86,10 +92,100 @@ pub struct CreateSnapshotResponse {
 pub struct Snapshot {
     pub snapshot_id: SnapshotId,
     pub log_id: LogId,
+    /// Legacy trim-safe LSN. Keep this meaning for old Admin nodes in rolling upgrades.
     pub min_applied_lsn: Lsn,
+    #[serde(default = "invalid_lsn")]
+    pub latest_snapshot_lsn: Lsn,
+    #[serde(default)]
+    pub snapshot_repository: String,
+}
+
+impl Snapshot {
+    /// Exact LSN paired with `snapshot_id`, falling back to the legacy field for old workers.
+    pub fn exact_min_applied_lsn(&self) -> Lsn {
+        if self.latest_snapshot_lsn == Lsn::INVALID {
+            self.min_applied_lsn
+        } else {
+            self.latest_snapshot_lsn
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum SnapshotError {
     SnapshotCreationFailed(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::{Deserialize, Serialize};
+
+    use crate::identifiers::{PartitionId, SnapshotId};
+    use crate::logs::{LogId, Lsn, SequenceNumber};
+
+    use super::{CreateSnapshotRequest, Snapshot};
+
+    #[derive(Serialize)]
+    struct OldCreateSnapshotRequest {
+        partition_id: PartitionId,
+        min_target_lsn: Option<Lsn>,
+    }
+
+    #[derive(Serialize, Deserialize)]
+    struct OldSnapshot {
+        snapshot_id: SnapshotId,
+        log_id: LogId,
+        min_applied_lsn: Lsn,
+    }
+
+    #[test]
+    fn decodes_snapshot_request_from_old_shape() {
+        let bytes = flexbuffers::to_vec(OldCreateSnapshotRequest {
+            partition_id: PartitionId::MIN,
+            min_target_lsn: Some(Lsn::new(42)),
+        })
+        .unwrap();
+
+        let request: CreateSnapshotRequest = flexbuffers::from_slice(&bytes).unwrap();
+        assert_eq!(request.partition_id, PartitionId::MIN);
+        assert_eq!(request.min_target_lsn, Some(Lsn::new(42)));
+        assert!(!request.protect_from_retention);
+    }
+
+    #[test]
+    fn decodes_snapshot_response_from_old_shape() {
+        let snapshot_id = SnapshotId::new();
+        let bytes = flexbuffers::to_vec(OldSnapshot {
+            snapshot_id,
+            log_id: LogId::MIN,
+            min_applied_lsn: Lsn::new(42),
+        })
+        .unwrap();
+
+        let snapshot: Snapshot = flexbuffers::from_slice(&bytes).unwrap();
+        assert_eq!(snapshot.snapshot_id, snapshot_id);
+        assert_eq!(snapshot.log_id, LogId::MIN);
+        assert_eq!(snapshot.min_applied_lsn, Lsn::new(42));
+        assert_eq!(snapshot.latest_snapshot_lsn, Lsn::INVALID);
+        assert_eq!(snapshot.exact_min_applied_lsn(), Lsn::new(42));
+        assert!(snapshot.snapshot_repository.is_empty());
+    }
+
+    #[test]
+    fn old_admin_decodes_new_snapshot_with_legacy_trim_safe_lsn() {
+        let snapshot_id = SnapshotId::new();
+        let bytes = flexbuffers::to_vec(Snapshot {
+            snapshot_id,
+            log_id: LogId::MIN,
+            min_applied_lsn: Lsn::new(10),
+            latest_snapshot_lsn: Lsn::new(42),
+            snapshot_repository: "s3://bucket/snapshots".to_owned(),
+        })
+        .unwrap();
+
+        let snapshot: OldSnapshot = flexbuffers::from_slice(&bytes).unwrap();
+        assert_eq!(snapshot.snapshot_id, snapshot_id);
+        assert_eq!(snapshot.log_id, LogId::MIN);
+        assert_eq!(snapshot.min_applied_lsn, Lsn::new(10));
+    }
 }

--- a/crates/worker/src/partition_processor_manager.rs
+++ b/crates/worker/src/partition_processor_manager.rs
@@ -925,6 +925,7 @@ where
         &mut self,
         partition_id: PartitionId,
         min_target_lsn: Option<Lsn>,
+        protect_from_retention: bool,
         sender: oneshot::Sender<SnapshotResult>,
     ) {
         let processor_state = match self.processor_states.get(&partition_id) {
@@ -959,6 +960,7 @@ where
             partition_id,
             min_target_lsn,
             snapshot_repository,
+            protect_from_retention,
             Some(sender),
         );
     }
@@ -1091,7 +1093,13 @@ where
             .take(limit);
 
         for partition_id in snapshot_partitions {
-            self.spawn_create_snapshot_task(partition_id, None, snapshot_repository.clone(), None);
+            self.spawn_create_snapshot_task(
+                partition_id,
+                None,
+                snapshot_repository.clone(),
+                false,
+                None,
+            );
         }
     }
 
@@ -1104,9 +1112,11 @@ where
         partition_id: PartitionId,
         min_target_lsn: Option<Lsn>,
         snapshot_repository: SnapshotRepository,
+        protect_from_retention: bool,
         sender: Option<oneshot::Sender<SnapshotResult>>,
     ) {
         if let Some(snapshot) = self.latest_snapshots.get(&partition_id)
+            && !protect_from_retention
             && min_target_lsn.is_some_and(|target_lsn| snapshot.archived_lsn >= target_lsn)
             && let Some(sender) = sender
         {
@@ -1157,6 +1167,7 @@ where
                     cluster_fingerprint,
                     node_name,
                     snapshot_repository,
+                    protect_from_retention,
                 };
 
                 let jitter = if sender.is_some() {
@@ -1289,7 +1300,16 @@ where
     fn handle_create_snapshot_request(&mut self, request: Incoming<Rpc<CreateSnapshotRequest>>) {
         let (sender, rx) = oneshot::channel();
         let (reciprocal, body) = request.split();
-        self.on_create_snapshot(body.partition_id, body.min_target_lsn, sender);
+        let snapshot_repository = self
+            .snapshot_repository
+            .as_ref()
+            .map(|repository| repository.destination().to_string());
+        self.on_create_snapshot(
+            body.partition_id,
+            body.min_target_lsn,
+            body.protect_from_retention,
+            sender,
+        );
         tokio::spawn(async move {
             let Ok(result) = rx.await else {
                 // dropping the reciprocal will notify the sender that the request will not
@@ -1302,6 +1322,9 @@ where
                         snapshot_id: snapshot.latest_snapshot_id,
                         log_id: snapshot.log_id,
                         min_applied_lsn: snapshot.archived_lsn,
+                        latest_snapshot_lsn: snapshot.latest_snapshot_lsn,
+                        snapshot_repository: snapshot_repository
+                            .expect("successful snapshot requires a configured repository"),
                     }),
                 }),
                 Err(err) => reciprocal.send(CreateSnapshotResponse {

--- a/server/tests/trim_gap_handling.rs
+++ b/server/tests/trim_gap_handling.rs
@@ -195,6 +195,7 @@ async fn fast_forward_over_trim_gap() -> googletest::Result<()> {
             partition_id: 0,
             min_target_lsn: Some(3),
             trim_log: true,
+            protect_from_retention: false,
         })
         .await?
         .into_inner();

--- a/tools/restatectl/Cargo.toml
+++ b/tools/restatectl/Cargo.toml
@@ -77,6 +77,7 @@ toml = { workspace = true }
 tokio = { workspace = true }
 tonic = { workspace = true, features = ["transport", "zstd", "gzip"] }
 tracing = { workspace = true }
+url = { workspace = true }
 
 [build-dependencies]
 vergen = { workspace = true, default-features = false, features = [

--- a/tools/restatectl/src/commands/snapshot/backup.rs
+++ b/tools/restatectl/src/commands/snapshot/backup.rs
@@ -1,0 +1,251 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::{Path, PathBuf};
+
+use cling::prelude::*;
+use futures::StreamExt;
+use tokio::io::AsyncWriteExt;
+
+use restate_cli_util::{c_println, c_warn};
+use restate_clock::WallClock;
+use restate_core::protobuf::cluster_ctrl_svc::{
+    CreatePartitionSnapshotRequest, new_cluster_ctrl_client,
+};
+use restate_types::cluster_backup::{
+    BackupConsistency, ClusterBackupDescriptor, PartitionBackupArtifact, PartitionBackupFailure,
+};
+use restate_types::identifiers::PartitionId;
+use restate_types::nodes_config::Role;
+
+use crate::connection::ConnectionInfo;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "backup")]
+pub struct BackupOpts {
+    /// Path at which to write the backup descriptor JSON.
+    #[arg(long, value_hint = clap::ValueHint::FilePath)]
+    output: PathBuf,
+
+    /// Snapshot repository configured on the source workers. Query parameters are not recorded.
+    #[arg(long, value_hint = clap::ValueHint::Url)]
+    snapshot_repository: String,
+
+    /// Include the whole global Schema metadata in the descriptor.
+    #[arg(long)]
+    include_schema: bool,
+
+    /// Maximum number of partition snapshots to create concurrently.
+    #[arg(long, default_value_t = 8)]
+    concurrency: usize,
+
+    /// Record topology and optional schema only; restore resolves each partition's latest snapshot.
+    #[arg(long)]
+    use_latest: bool,
+
+    /// Replace an existing descriptor at the output path.
+    #[arg(long)]
+    overwrite: bool,
+}
+
+async fn backup(connection: &ConnectionInfo, opts: &BackupOpts) -> anyhow::Result<()> {
+    if opts.concurrency == 0 {
+        anyhow::bail!("--concurrency must be greater than zero");
+    }
+    if !opts.overwrite && tokio::fs::try_exists(&opts.output).await? {
+        anyhow::bail!(
+            "output descriptor '{}' already exists; pass --overwrite to replace it",
+            opts.output.display()
+        );
+    }
+
+    c_warn!(
+        "This creates a best-effort backup. Partition snapshots are not a consistent cluster-wide cut."
+    );
+
+    let source_snapshot_repository = normalize_snapshot_repository(&opts.snapshot_repository)?;
+    let nodes_config = connection.get_nodes_configuration().await?;
+    let partition_table = connection.get_partition_table().await?;
+    let schema = if opts.include_schema {
+        Some(connection.get_schema().await?)
+    } else {
+        None
+    };
+
+    let mut descriptor = ClusterBackupDescriptor {
+        version: ClusterBackupDescriptor::VERSION,
+        created_at: WallClock::recent_ms(),
+        consistency: BackupConsistency::BestEffort,
+        source_snapshot_repository: source_snapshot_repository.clone(),
+        source_cluster_name: nodes_config.cluster_name().to_owned(),
+        source_cluster_fingerprint: nodes_config.cluster_fingerprint(),
+        source_cluster_features: nodes_config.features(),
+        partition_table: partition_table.clone(),
+        schema,
+        artifacts: None,
+        failures: vec![],
+    };
+
+    if !opts.use_latest {
+        c_warn!(
+            "Exact backup artifacts are protected from automatic snapshot retention and accumulate until repository metadata and objects are cleaned up together."
+        );
+        let partitions = partition_table
+            .iter()
+            .map(|(partition_id, partition)| (*partition_id, partition.key_range))
+            .collect::<Vec<_>>();
+        let mut artifacts = Vec::with_capacity(partitions.len());
+        let mut failures = vec![];
+        let mut snapshots = futures::stream::iter(partitions)
+            .map(|(partition_id, key_range)| {
+                create_snapshot(
+                    connection.clone(),
+                    partition_id,
+                    key_range,
+                    source_snapshot_repository.clone(),
+                )
+            })
+            .buffer_unordered(opts.concurrency);
+
+        while let Some(result) = snapshots.next().await {
+            match result {
+                Ok(artifact) => artifacts.push(artifact),
+                Err((partition_id, error)) => failures.push(PartitionBackupFailure {
+                    partition_id,
+                    message: error.to_string(),
+                }),
+            }
+        }
+        artifacts.sort_by_key(|artifact| artifact.partition_id);
+        failures.sort_by_key(|failure| failure.partition_id);
+        descriptor.artifacts = Some(artifacts);
+        descriptor.failures = failures;
+    }
+
+    write_descriptor(&opts.output, &descriptor).await?;
+    c_println!("{}", opts.output.display());
+
+    match descriptor.validate()? {
+        restate_types::cluster_backup::BackupArtifactSet::TopologyOnly if opts.use_latest => Ok(()),
+        restate_types::cluster_backup::BackupArtifactSet::Complete => Ok(()),
+        restate_types::cluster_backup::BackupArtifactSet::TopologyOnly => {
+            unreachable!("snapshot capture always records an artifact set")
+        }
+        restate_types::cluster_backup::BackupArtifactSet::Incomplete => {
+            c_warn!(
+                "Backup descriptor was written but is incomplete; inspect {} before retrying.",
+                opts.output.display()
+            );
+            anyhow::bail!("failed to create snapshots for one or more partitions")
+        }
+    }
+}
+
+async fn create_snapshot(
+    connection: ConnectionInfo,
+    partition_id: PartitionId,
+    key_range: restate_types::sharding::KeyRange,
+    expected_repository: String,
+) -> Result<PartitionBackupArtifact, (PartitionId, anyhow::Error)> {
+    let response = connection
+        .try_each(Some(Role::Admin), |channel| async {
+            new_cluster_ctrl_client(channel, &restate_cli_util::CliContext::get().network)
+                .create_partition_snapshot(CreatePartitionSnapshotRequest {
+                    partition_id: partition_id.into(),
+                    min_target_lsn: None,
+                    trim_log: false,
+                    protect_from_retention: true,
+                })
+                .await
+        })
+        .await
+        .map_err(|error| (partition_id, error.into()))?
+        .into_inner();
+
+    validate_worker_repository(&response.snapshot_repository, &expected_repository)
+        .map_err(|error| (partition_id, error))?;
+
+    Ok(PartitionBackupArtifact {
+        partition_id,
+        snapshot_id: response
+            .snapshot_id
+            .parse()
+            .map_err(|error| (partition_id, anyhow::Error::from(error)))?,
+        log_id: response.log_id.into(),
+        min_applied_lsn: response.min_applied_lsn.into(),
+        key_range,
+    })
+}
+
+fn normalize_snapshot_repository(value: &str) -> anyhow::Result<String> {
+    let mut repository = url::Url::parse(value)
+        .map_err(|error| anyhow::anyhow!("invalid --snapshot-repository URL: {error}"))?;
+    repository.set_query(None);
+    if repository.path() != "/" {
+        let path = repository.path().trim_end_matches('/').to_owned();
+        repository.set_path(&path);
+    }
+    Ok(repository.to_string())
+}
+
+fn validate_worker_repository(reported: &str, expected: &str) -> anyhow::Result<()> {
+    let reported = normalize_snapshot_repository(reported).map_err(|error| {
+        anyhow::anyhow!(
+            "worker did not report a valid snapshot repository; it may not support protected backups: {error}"
+        )
+    })?;
+    if reported != expected {
+        anyhow::bail!(
+            "worker wrote snapshot to '{reported}', but --snapshot-repository resolves to '{expected}'"
+        );
+    }
+    Ok(())
+}
+
+async fn write_descriptor(path: &Path, descriptor: &ClusterBackupDescriptor) -> anyhow::Result<()> {
+    let content = serde_json::to_vec_pretty(descriptor)?;
+    let temporary_path = path.with_extension(format!("{}.tmp", std::process::id()));
+    let mut file = tokio::fs::OpenOptions::new()
+        .create_new(true)
+        .write(true)
+        .open(&temporary_path)
+        .await?;
+    file.write_all(&content).await?;
+    file.sync_all().await?;
+    drop(file);
+    tokio::fs::rename(&temporary_path, path).await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{normalize_snapshot_repository, validate_worker_repository};
+
+    #[test]
+    fn normalizes_snapshot_repository_like_the_server() {
+        assert_eq!(
+            normalize_snapshot_repository("s3://bucket/backups/?region=ignored").unwrap(),
+            "s3://bucket/backups"
+        );
+        assert_eq!(
+            normalize_snapshot_repository("file:///").unwrap(),
+            "file:///"
+        );
+        assert!(normalize_snapshot_repository("not a URL").is_err());
+    }
+
+    #[test]
+    fn rejects_old_or_mismatched_worker_repository() {
+        assert!(validate_worker_repository("", "s3://bucket/backups").is_err());
+        assert!(validate_worker_repository("s3://bucket/other", "s3://bucket/backups").is_err());
+        validate_worker_repository("s3://bucket/backups/?ignored=true", "s3://bucket/backups")
+            .unwrap();
+    }
+}

--- a/tools/restatectl/src/commands/snapshot/create_snapshot.rs
+++ b/tools/restatectl/src/commands/snapshot/create_snapshot.rs
@@ -89,6 +89,7 @@ async fn inner_create_snapshot(
         partition_id: partition_id.into(),
         min_target_lsn: opts.min_lsn,
         trim_log: opts.trim_log,
+        protect_from_retention: false,
     };
 
     let response = connection

--- a/tools/restatectl/src/commands/snapshot/mod.rs
+++ b/tools/restatectl/src/commands/snapshot/mod.rs
@@ -8,12 +8,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+mod backup;
 mod create_snapshot;
 
 use cling::prelude::*;
 
 #[derive(Run, Subcommand, Clone)]
+#[allow(clippy::enum_variant_names)] // Preserve the existing `create-snapshot` CLI spelling.
 pub enum Snapshot {
+    /// Capture a V0 cluster backup descriptor.
+    Backup(backup::BackupOpts),
     /// Create.
     CreateSnapshot(create_snapshot::CreateSnapshotOpts),
 }

--- a/tools/restatectl/src/connection.rs
+++ b/tools/restatectl/src/connection.rs
@@ -27,6 +27,7 @@ use restate_core::protobuf::node_ctl_svc::{
 use restate_metadata_store::ReadModifyWriteError;
 use restate_types::errors;
 use restate_types::partition_table::PartitionTable;
+use restate_types::schema::Schema;
 use restate_types::{
     Version, Versioned,
     logs::metadata::Logs,
@@ -147,6 +148,9 @@ pub struct ConnectionInfo {
     partition_table: Arc<Mutex<Option<PartitionTable>>>,
 
     #[clap(skip)]
+    schema: Arc<Mutex<Option<Schema>>>,
+
+    #[clap(skip)]
     open_connections: Arc<Mutex<HashMap<AdvertisedAddress<FabricPort>, Channel>>>,
 
     #[clap(skip)]
@@ -230,10 +234,13 @@ impl ConnectionInfo {
         Fut: Future<Output = Result<T, E>>,
     {
         let effective_addresses = self.get_effective_addresses();
-        let mut open_connections = self.open_connections.lock().await;
 
         if let Some(address) = effective_addresses.into_iter().next() {
-            if let Some(channel) = self.connect_internal(address, &mut open_connections).await {
+            let channel = {
+                let mut open_connections = self.open_connections.lock().await;
+                self.connect_internal(address, &mut open_connections)
+            };
+            if let Some(channel) = channel {
                 if let Some(required_role) = role {
                     let mut client =
                         new_node_ctl_client(channel.clone(), &CliContext::get().network);
@@ -359,6 +366,34 @@ impl ConnectionInfo {
             MetadataKind::PartitionTable,
             guard,
             |ident| Version::from(ident.partition_table_version),
+        )
+        .await
+    }
+
+    /// Gets Schema metadata using the same majority/version selection as other global metadata.
+    pub async fn get_schema(&self) -> Result<Schema, ConnectionInfoError> {
+        let guard = self.schema.lock().await;
+
+        if self.is_single_address_mode() {
+            return self
+                .get_metadata_single_address(
+                    MetadataKind::Schema,
+                    guard,
+                    |ident| Version::from(ident.schema_version),
+                    "schema metadata",
+                )
+                .await;
+        }
+
+        let nodes_config = self.get_nodes_configuration().await?;
+        let addresses = self.get_majority_consensus_addresses(&nodes_config).await;
+
+        self.get_latest_metadata(
+            addresses.into_iter(),
+            (nodes_config.len() / 2) + 1,
+            MetadataKind::Schema,
+            guard,
+            |ident| Version::from(ident.schema_version),
         )
         .await
     }
@@ -500,7 +535,13 @@ impl ConnectionInfo {
         }
 
         let nodes_config = self.get_nodes_configuration().await?;
-        let mut open_connections = self.open_connections.lock().await;
+        let connected_addresses = self
+            .open_connections
+            .lock()
+            .await
+            .keys()
+            .cloned()
+            .collect::<HashSet<_>>();
 
         let iterator = match role {
             Some(role) => Either::Left(nodes_config.iter_role(role)),
@@ -509,21 +550,24 @@ impl ConnectionInfo {
         .sorted_by(|a, b| {
             // nodes for which we already have open channels get higher precedence.
             match (
-                open_connections.contains_key(&a.1.address),
-                open_connections.contains_key(&b.1.address),
+                connected_addresses.contains(&a.1.address),
+                connected_addresses.contains(&b.1.address),
             ) {
                 (true, false) => Ordering::Less,
                 (false, true) => Ordering::Greater,
                 (_, _) => a.0.cmp(&b.0),
             }
-        });
+        })
+        .map(|(node_id, node)| (node_id, node.clone()))
+        .collect::<Vec<_>>();
 
         let mut errors = NodesErrors::default();
 
         for (_, node) in iterator {
-            let channel = self
-                .connect_internal(&node.address, &mut open_connections)
-                .await;
+            let channel = {
+                let mut open_connections = self.open_connections.lock().await;
+                self.connect_internal(&node.address, &mut open_connections)
+            };
 
             if let Some(channel) = channel {
                 debug!("Trying {}...", node.address);
@@ -568,18 +612,18 @@ impl ConnectionInfo {
         &self,
         address: &AdvertisedAddress<FabricPort>,
     ) -> Result<Channel, ConnectionInfoError> {
-        self.connect_internal(address, &mut self.open_connections.lock().await)
-            .await
+        let mut open_connections = self.open_connections.lock().await;
+        self.connect_internal(address, &mut open_connections)
             .map(Ok)
             .unwrap_or(Err(ConnectionInfoError::NodeUnreachable))
     }
 
     /// Creates and returns a (lazy) connection to the specified address, or `None` if this
     /// address was previously flagged as unreachable.
-    async fn connect_internal(
+    fn connect_internal(
         &self,
         address: &AdvertisedAddress<FabricPort>,
-        open_connections: &mut MutexGuard<'_, HashMap<AdvertisedAddress<FabricPort>, Channel>>,
+        open_connections: &mut HashMap<AdvertisedAddress<FabricPort>, Channel>,
     ) -> Option<Channel> {
         if self.dead_nodes.read().unwrap().contains(address) {
             debug!(
@@ -734,5 +778,55 @@ impl Display for NodesErrors {
 impl std::error::Error for NodesErrors {
     fn description(&self) -> &str {
         "aggregated nodes error"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use tokio::sync::{Barrier, Mutex};
+
+    use super::ConnectionInfo;
+
+    #[tokio::test]
+    async fn concurrent_operations_do_not_hold_connection_cache_lock() {
+        let connection = ConnectionInfo {
+            address: vec![],
+            single_address: Some("http://127.0.0.1:5122/".parse().unwrap()),
+            nodes_configuration: Default::default(),
+            logs: Default::default(),
+            partition_table: Default::default(),
+            schema: Default::default(),
+            open_connections: Arc::new(Mutex::new(HashMap::default())),
+            dead_nodes: Default::default(),
+        };
+        let barrier = Arc::new(Barrier::new(3));
+
+        let first = connection.try_each(None, |_| {
+            let barrier = Arc::clone(&barrier);
+            async move {
+                barrier.wait().await;
+                Ok::<_, tonic::Status>(())
+            }
+        });
+        let second = connection.try_each(None, |_| {
+            let barrier = Arc::clone(&barrier);
+            async move {
+                barrier.wait().await;
+                Ok::<_, tonic::Status>(())
+            }
+        });
+
+        let (first_result, second_result, _) =
+            tokio::time::timeout(Duration::from_secs(1), async {
+                tokio::join!(first, second, barrier.wait())
+            })
+            .await
+            .expect("both operations should enter their futures concurrently");
+        first_result.unwrap();
+        second_result.unwrap();
     }
 }


### PR DESCRIPTION
Experimental recovery stack — PR 1 of 3.

Adds a versioned portable backup descriptor and parallel `restatectl snapshots backup` capture. Exact mode records and retention-protects the immutable snapshot ID/LSN selected for each partition; topology-only mode supports pre-existing snapshots. Descriptors may include the deployment schema and record the source cluster feature set required for safe restore.

The snapshot RPC keeps rolling-upgrade compatibility: the legacy LSN remains trim-safe while new fields carry exact identity and the authoritative normalized repository. V3 repository pointers preserve protected snapshots across rolling retention without pinning the Bifrost trim floor. Snapshot downloads validate every repository-supplied component name before staging, preventing path escape from crafted metadata.

Safety boundary: this is a best-effort, non-quiescent capture, not a cross-partition consistent cut. Exact mode verifies the worker repository; topology-only mode cannot verify or protect operator-selected artifacts.

Stack: base PR.