### PR TITLE
restatectl: restore V0 backups onto a fresh cluster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8351,6 +8351,7 @@ dependencies = [
  "restate-rocksdb",
  "restate-service-client",
  "restate-service-protocol-v4",
+ "restate-storage-api",
  "restate-storage-query-datafusion",
  "restate-tracing-instrumentation",
  "restate-types",
@@ -8371,6 +8372,7 @@ dependencies = [
  "tonic",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/crates/core/protobuf/node_ctl_svc.proto
+++ b/crates/core/protobuf/node_ctl_svc.proto
@@ -33,6 +33,9 @@ service NodeCtlSvc {
   // Trigger manual compaction of RocksDB databases on this node.
   rpc TriggerCompaction(TriggerCompactionRequest)
       returns (TriggerCompactionResponse);
+
+  // Restore a V0 cluster backup onto an unprovisioned node.
+  rpc RestoreCluster(RestoreClusterRequest) returns (RestoreClusterResponse);
 }
 
 enum ClusterFeature {
@@ -140,4 +143,20 @@ message DatabaseCompactionResult {
   bool success = 2;
   optional string error = 3;
   uint32 column_families_compacted = 4;
+}
+
+message RestoreClusterRequest {
+  // A serialized restate_types::cluster_backup::ClusterBackupDescriptor.
+  bytes descriptor_json = 1;
+  bool restore_schema = 2;
+  bool preserve_cluster_fingerprint = 3;
+  bool dry_run = 4;
+}
+
+message RestoreClusterResponse {
+  bool dry_run = 1;
+  uint32 partition_count = 2;
+  bool schema_restored = 3;
+  string target_cluster_name = 4;
+  optional string target_cluster_fingerprint = 5;
 }

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -48,6 +48,7 @@ restate-rocksdb = { workspace = true }
 restate-service-client = { workspace = true }
 restate-service-protocol-v4 = { workspace = true, features = ["discovery", "serdes"] }
 restate-storage-query-datafusion = { workspace = true }
+restate-storage-api = { workspace = true }
 restate-tracing-instrumentation = { workspace = true, features = ["prometheus"] }
 restate-types = { workspace = true, features = ["clap"] }
 restate-wal-protocol = { workspace = true }
@@ -80,6 +81,7 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true }
 tonic = { workspace = true, features = ["gzip", "zstd"] }
 tracing = { workspace = true }
+url = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemalloc_pprof = { version = "0.9", default-features = false, features = ["symbolize"] }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -13,6 +13,7 @@ mod init;
 mod introspection;
 mod metric_definitions;
 mod network_server;
+mod restore;
 mod roles;
 
 use std::sync::Arc;
@@ -154,6 +155,7 @@ pub struct Node {
     is_provisioned: bool,
     prometheus: Prometheus,
     address_book: AddressBook,
+    partition_store_manager: Arc<PartitionStoreManager>,
 }
 
 impl Node {
@@ -459,6 +461,7 @@ impl Node {
             is_provisioned,
             prometheus,
             address_book,
+            partition_store_manager,
         })
     }
 
@@ -468,6 +471,8 @@ impl Node {
 
         let metadata_writer = self.metadata_manager.writer();
         let metadata = Metadata::current();
+        let partition_store_manager = Arc::clone(&self.partition_store_manager);
+        let restore_target_is_unprovisioned = !self.is_provisioned && !config.common.auto_provision;
 
         // Start metadata manager
         spawn_metadata_manager(self.metadata_manager)?;
@@ -482,6 +487,8 @@ impl Node {
                     self.server_builder,
                     metadata_writer,
                     self.prometheus,
+                    partition_store_manager,
+                    restore_target_is_unprovisioned,
                 )
                 .await?;
                 Ok(())
@@ -796,10 +803,22 @@ fn create_initial_nodes_configuration(
     common_opts: &CommonOptions,
     features: EnumSet<ClusterFeature>,
 ) -> NodesConfiguration {
+    create_initial_nodes_configuration_with_fingerprint(
+        common_opts,
+        features,
+        ClusterFingerprint::generate(),
+    )
+}
+
+fn create_initial_nodes_configuration_with_fingerprint(
+    common_opts: &CommonOptions,
+    features: EnumSet<ClusterFeature>,
+    fingerprint: ClusterFingerprint,
+) -> NodesConfiguration {
     let mut initial_nodes_configuration = NodesConfiguration::new(
         Version::MIN,
         common_opts.cluster_name().to_owned(),
-        ClusterFingerprint::generate(),
+        fingerprint,
     );
     initial_nodes_configuration.set_features(features);
     let my_advertised_address =

--- a/crates/node/src/network_server/grpc_svc_handler.rs
+++ b/crates/node/src/network_server/grpc_svc_handler.rs
@@ -8,7 +8,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::cmp::max_by_key;
+use std::{cmp::max_by_key, sync::Arc};
 
 use anyhow::Context;
 use bytes::BytesMut;
@@ -30,33 +30,55 @@ use restate_core::protobuf::node_ctl_svc::node_ctl_svc_server::{NodeCtlSvc, Node
 use restate_core::protobuf::node_ctl_svc::{
     ClusterHealthResponse, DatabaseCompactionResult, EmbeddedMetadataClusterHealth,
     GetMetadataRequest, GetMetadataResponse, IdentResponse, ProvisionClusterRequest,
-    ProvisionClusterResponse, TriggerCompactionRequest, TriggerCompactionResponse,
-    cluster_features_from_proto,
+    ProvisionClusterResponse, RestoreClusterRequest, RestoreClusterResponse,
+    TriggerCompactionRequest, TriggerCompactionResponse, cluster_features_from_proto,
 };
 use restate_core::{Identification, MetadataWriter};
 use restate_core::{Metadata, MetadataKind};
 use restate_metadata_store::{MetadataStoreClient, ReadError, WriteError};
+use restate_partition_store::PartitionStoreManager;
 use restate_rocksdb::RocksDbManager;
 use restate_types::Version;
+use restate_types::cluster_backup::ClusterBackupDescriptor;
 use restate_types::config::{Configuration, NetworkingOptions};
 use restate_types::errors::{ConversionError, MaybeRetryableError};
 use restate_types::logs::metadata::{NodeSetSize, ProviderConfiguration};
 use restate_types::metadata::VersionedValue;
-use restate_types::nodes_config::{ClusterFeature, Role};
+use restate_types::metadata_store::keys::NODES_CONFIG_KEY;
+use restate_types::nodes_config::{ClusterFeature, NodesConfiguration, Role};
 use restate_types::protobuf::cluster::ClusterConfiguration as ProtoClusterConfiguration;
 use restate_types::protobuf::common::DatabaseKind;
 use restate_types::replication::ReplicationProperty;
 use restate_types::storage::StorageCodec;
 
+use crate::restore::{self, RestoreOptions};
 use crate::{ClusterConfiguration, provision_cluster_metadata};
+
+fn metadata_store_is_explicitly_unprovisioned(error: &ReadError) -> bool {
+    error
+        .to_string()
+        .contains("Metadata store has not been provisioned yet")
+}
 
 pub struct NodeCtlSvcHandler {
     metadata_writer: MetadataWriter,
+    partition_store_manager: Arc<PartitionStoreManager>,
+    restore_target_is_unprovisioned: bool,
+    provision_lock: tokio::sync::Mutex<()>,
 }
 
 impl NodeCtlSvcHandler {
-    pub fn new(metadata_writer: MetadataWriter) -> Self {
-        Self { metadata_writer }
+    pub fn new(
+        metadata_writer: MetadataWriter,
+        partition_store_manager: Arc<PartitionStoreManager>,
+        restore_target_is_unprovisioned: bool,
+    ) -> Self {
+        Self {
+            metadata_writer,
+            partition_store_manager,
+            restore_target_is_unprovisioned,
+            provision_lock: tokio::sync::Mutex::new(()),
+        }
     }
 
     pub fn into_server(self, config: &NetworkingOptions) -> NodeCtlSvcServer<Self> {
@@ -168,14 +190,16 @@ impl NodeCtlSvc for NodeCtlSvcHandler {
         request: Request<ProvisionClusterRequest>,
     ) -> Result<Response<ProvisionClusterResponse>, Status> {
         let request = request.into_inner();
-        let config = Configuration::pinned();
-
         let dry_run = request.dry_run;
         let disabled = cluster_features_from_proto(&request.disabled_features)
             .map_err(|err| Status::invalid_argument(err.to_string()))?;
         let features = ClusterFeature::default_features() - disabled;
-        let cluster_configuration = Self::resolve_cluster_configuration(&config, request)
-            .map_err(|err| Status::invalid_argument(err.to_string()))?;
+        let (cluster_configuration, common_options) = {
+            let config = Configuration::pinned();
+            let cluster_configuration = Self::resolve_cluster_configuration(&config, request)
+                .map_err(|err| Status::invalid_argument(err.to_string()))?;
+            (cluster_configuration, config.common.clone())
+        };
 
         if dry_run {
             return Ok(Response::new(ProvisionClusterResponse::dry_run(
@@ -184,9 +208,11 @@ impl NodeCtlSvc for NodeCtlSvcHandler {
             )));
         }
 
+        let _provision_guard = self.provision_lock.lock().await;
+
         let newly_provisioned = provision_cluster_metadata(
             &self.metadata_writer,
-            &config.common,
+            &common_options,
             &cluster_configuration,
             features,
         )
@@ -198,11 +224,113 @@ impl NodeCtlSvc for NodeCtlSvcHandler {
                 "The cluster has already been provisioned",
             ));
         }
-
         Ok(Response::new(ProvisionClusterResponse::provisioned(
             ProtoClusterConfiguration::from(cluster_configuration),
             features,
         )))
+    }
+
+    async fn restore_cluster(
+        &self,
+        request: Request<RestoreClusterRequest>,
+    ) -> Result<Response<RestoreClusterResponse>, Status> {
+        let _provision_guard = self.provision_lock.lock().await;
+        if !self.restore_target_is_unprovisioned {
+            return Err(Status::already_exists(
+                "cluster restore requires a fresh, unprovisioned target node",
+            ));
+        }
+
+        let request = request.into_inner();
+        let descriptor: ClusterBackupDescriptor = serde_json::from_slice(&request.descriptor_json)
+            .map_err(|error| {
+                Status::invalid_argument(format!("invalid backup descriptor JSON: {error}"))
+            })?;
+        let (common_options, target_cluster_name, provider, snapshots_options, restore_staging_dir) = {
+            let configuration = Configuration::pinned();
+            (
+                configuration.common.clone(),
+                configuration.common.cluster_name().to_owned(),
+                configuration.bifrost.default_provider,
+                configuration.worker.snapshots.clone(),
+                configuration
+                    .worker
+                    .storage
+                    .snapshots_staging_dir()
+                    .join("restore"),
+            )
+        };
+        restore::validate_target_configuration(&common_options, provider)
+            .map_err(|error| Status::failed_precondition(error.to_string()))?;
+
+        // The on-disk cluster marker is not authoritative if it was lost independently from an
+        // existing embedded metadata database. Check the metadata store before any restore reads
+        // can lead to destructive local snapshot imports. A fresh built-in store reports its
+        // explicit unprovisioned state as Unavailable until `provision` initializes it.
+        match self
+            .metadata_writer
+            .raw_metadata_store_client()
+            .get::<NodesConfiguration>(NODES_CONFIG_KEY.clone())
+            .await
+        {
+            Ok(Some(_)) => {
+                return Err(Status::already_exists(
+                    "cluster metadata is already provisioned; refusing to import snapshots",
+                ));
+            }
+            Ok(None) => {
+                return Err(Status::failed_precondition(
+                    "target metadata store is initialized without NodesConfiguration; refusing to import snapshots",
+                ));
+            }
+            Err(error) if metadata_store_is_explicitly_unprovisioned(&error) => {}
+            Err(error) => {
+                return Err(Status::unavailable(format!(
+                    "failed verifying that target metadata is unprovisioned: {error}"
+                )));
+            }
+        }
+        let plan = restore::preflight(
+            descriptor,
+            RestoreOptions {
+                restore_schema: request.restore_schema,
+                preserve_cluster_fingerprint: request.preserve_cluster_fingerprint,
+            },
+            &common_options,
+            provider,
+            &snapshots_options,
+            restore_staging_dir,
+        )
+        .await
+        .map_err(|error| Status::failed_precondition(error.to_string()))?;
+
+        let partition_count = u32::try_from(plan.partition_count())
+            .expect("a Restate partition table contains at most u16::MAX partitions");
+        let schema_restored = plan.schema_restored();
+        let target_cluster_fingerprint = Some(plan.target_fingerprint().to_string());
+        if !request.dry_run {
+            let newly_provisioned = restore::apply(
+                plan,
+                &self.metadata_writer,
+                &common_options,
+                &self.partition_store_manager,
+            )
+            .await
+            .map_err(|error| Status::internal(error.to_string()))?;
+            if !newly_provisioned {
+                return Err(Status::already_exists(
+                    "the target cluster was provisioned concurrently",
+                ));
+            }
+        }
+
+        Ok(Response::new(RestoreClusterResponse {
+            dry_run: request.dry_run,
+            partition_count,
+            schema_restored,
+            target_cluster_name,
+            target_cluster_fingerprint,
+        }))
     }
 
     async fn cluster_health(
@@ -461,6 +589,20 @@ fn write_err_to_status(err: WriteError) -> Status {
 #[cfg(test)]
 mod tests {
     use restate_types::protobuf::common::DatabaseKind;
+
+    use super::*;
+
+    #[test]
+    fn recognizes_only_explicit_unprovisioned_metadata_errors() {
+        let unprovisioned = ReadError::retryable(std::io::Error::other(
+            "Metadata store has not been provisioned yet",
+        ));
+        assert!(metadata_store_is_explicitly_unprovisioned(&unprovisioned));
+
+        let unavailable =
+            ReadError::retryable(std::io::Error::other("metadata service unavailable"));
+        assert!(!metadata_store_is_explicitly_unprovisioned(&unavailable));
+    }
 
     #[test]
     fn database_kind_db_names() {

--- a/crates/node/src/network_server/service.rs
+++ b/crates/node/src/network_server/service.rs
@@ -8,6 +8,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::sync::Arc;
+
 use axum::Json;
 use axum::routing::{MethodFilter, get, on};
 
@@ -15,6 +17,7 @@ use restate_core::TaskCenter;
 use restate_core::network::grpc::CoreNodeSvcHandler;
 use restate_core::network::{ConnectionManager, NetworkServerBuilder};
 use restate_core::{Identification, MetadataWriter};
+use restate_partition_store::PartitionStoreManager;
 use restate_tracing_instrumentation::prometheus_metrics::Prometheus;
 use restate_types::config::Configuration;
 
@@ -31,6 +34,8 @@ impl NetworkServer {
         mut server_builder: NetworkServerBuilder,
         metadata_writer: MetadataWriter,
         prometheus: Prometheus,
+        partition_store_manager: Arc<PartitionStoreManager>,
+        restore_target_is_unprovisioned: bool,
     ) -> Result<(), anyhow::Error> {
         // Configure Metric Exporter
         let mut state_builder = NodeCtrlHandlerStateBuilder::default();
@@ -81,8 +86,12 @@ impl NetworkServer {
         );
 
         server_builder.register_grpc_service(
-            NodeCtlSvcHandler::new(metadata_writer)
-                .into_server(&Configuration::pinned().networking),
+            NodeCtlSvcHandler::new(
+                metadata_writer,
+                partition_store_manager,
+                restore_target_is_unprovisioned,
+            )
+            .into_server(&Configuration::pinned().networking),
             restate_core::protobuf::node_ctl_svc::FILE_DESCRIPTOR_SET,
         );
 

--- a/crates/node/src/restore.rs
+++ b/crates/node/src/restore.rs
@@ -1,0 +1,609 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! V0 restore is deliberately a single-node bootstrap operation. It establishes a fresh target
+//! cluster from a portable backup descriptor; it does not restore a multi-node deployment.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, bail, ensure};
+use restate_core::MetadataWriter;
+use restate_partition_store::PartitionStoreManager;
+use restate_partition_store::snapshots::{SnapshotRecord, SnapshotRepository, SnapshotSource};
+use restate_storage_api::Transaction;
+use restate_storage_api::fsm_table::{ReadFsmTable, WriteFsmTable};
+use restate_types::cluster_backup::{
+    BackupArtifactSet, ClusterBackupDescriptor, PartitionBackupArtifact,
+};
+use restate_types::config::{CommonOptions, MetadataClientKind, SnapshotsOptions};
+use restate_types::epoch::EpochMetadata;
+use restate_types::logs::builder::LogsBuilder;
+use restate_types::logs::metadata::{
+    Chain, LogletParams, Logs, LogsConfiguration, ProviderConfiguration, ProviderKind,
+    SegmentIndex, new_single_node_loglet_params,
+};
+use restate_types::logs::{LogId, LogletId, Lsn, SequenceNumber};
+use restate_types::metadata::Precondition;
+use restate_types::metadata_store::keys::partition_processor_epoch_key;
+use restate_types::nodes_config::{ClusterFingerprint, Role};
+use restate_types::partition_table::{
+    Partition, PartitionReplication, PartitionTable, PartitionTableBuilder,
+};
+use restate_types::partitions::PartitionConfiguration;
+use restate_types::replicated_loglet::ReplicatedLogletParams;
+use restate_types::replication::{NodeSet, ReplicationProperty};
+use restate_types::{GenerationalNodeId, Version};
+
+use crate::{
+    create_initial_nodes_configuration_with_fingerprint, write_initial_logs_dont_fail_if_it_exists,
+    write_initial_value_dont_fail_if_it_exists,
+};
+
+#[derive(Debug, Clone, Copy)]
+pub struct RestoreOptions {
+    pub restore_schema: bool,
+    pub preserve_cluster_fingerprint: bool,
+}
+
+pub struct RestorePlan {
+    descriptor: ClusterBackupDescriptor,
+    artifacts: Vec<ResolvedArtifact>,
+    target_fingerprint: ClusterFingerprint,
+    restore_schema: bool,
+    provider: ProviderKind,
+    source_repository: SnapshotRepository,
+}
+
+#[derive(Debug)]
+struct ResolvedArtifact {
+    partition: Partition,
+    record: SnapshotRecord,
+}
+
+#[derive(Debug)]
+struct ImportedPartition {
+    partition: Partition,
+    cached_epoch: Option<restate_storage_api::fsm_table::CachedEpochMetadata>,
+    applied_lsn: Lsn,
+}
+
+impl RestorePlan {
+    pub fn partition_count(&self) -> usize {
+        self.artifacts.len()
+    }
+
+    pub fn schema_restored(&self) -> bool {
+        self.restore_schema && self.descriptor.schema.is_some()
+    }
+
+    pub fn target_fingerprint(&self) -> ClusterFingerprint {
+        self.target_fingerprint
+    }
+}
+
+/// Resolves every backup artifact without touching local partition stores or metadata. For a
+/// topology-only descriptor, this pins the current `latest.json` target before the caller can
+/// begin downloading it.
+pub async fn preflight(
+    descriptor: ClusterBackupDescriptor,
+    options: RestoreOptions,
+    common_options: &CommonOptions,
+    provider: ProviderKind,
+    snapshots_options: &SnapshotsOptions,
+    restore_staging_dir: PathBuf,
+) -> anyhow::Result<RestorePlan> {
+    validate_target_configuration(common_options, provider)?;
+    let artifact_set = descriptor.validate().context("invalid backup descriptor")?;
+    ensure!(
+        artifact_set != BackupArtifactSet::Incomplete,
+        "an incomplete backup descriptor cannot be restored"
+    );
+    ensure!(
+        !options.restore_schema || descriptor.schema.is_some(),
+        "restoring schema requires a backup descriptor containing schema metadata"
+    );
+
+    let source_destination = normalized_repository_root(
+        &descriptor.source_snapshot_repository,
+        "source snapshot repository",
+    )?;
+    ensure_distinct_repository_roots(&source_destination, snapshots_options)?;
+    let source_repository = SnapshotRepository::new_for_source(
+        snapshots_options,
+        source_destination,
+        restore_staging_dir,
+    )
+    .await
+    .context("failed opening source snapshot repository")?;
+
+    let target_fingerprint = target_fingerprint(
+        options.preserve_cluster_fingerprint,
+        descriptor.source_cluster_fingerprint,
+    )?;
+    let source = SnapshotSource::new(
+        descriptor.source_cluster_name.clone(),
+        descriptor.source_cluster_fingerprint,
+    );
+
+    let mut artifacts = Vec::with_capacity(descriptor.partition_table.len());
+    for (partition_id, partition) in descriptor.partition_table.iter() {
+        let record = match artifact_set {
+            BackupArtifactSet::TopologyOnly => source_repository
+                .resolve_latest_for_source(*partition_id, &source)
+                .await
+                .with_context(|| {
+                    format!("failed resolving latest snapshot for partition {partition_id}")
+                })?
+                .ok_or_else(|| {
+                    anyhow::anyhow!("no snapshot exists for partition {partition_id}")
+                })?,
+            BackupArtifactSet::Complete => {
+                let artifact = exact_artifact(&descriptor, *partition_id)?;
+                source_repository
+                    .inspect_exact(
+                        artifact.partition_id,
+                        artifact.snapshot_id,
+                        artifact.min_applied_lsn,
+                        &source,
+                    )
+                    .await
+                    .with_context(|| {
+                        format!("failed inspecting snapshot for partition {partition_id}")
+                    })?
+            }
+            BackupArtifactSet::Incomplete => unreachable!("checked above"),
+        };
+        validate_record(partition, &record)?;
+        ensure!(
+            record.min_applied_lsn != Lsn::MAX,
+            "snapshot for partition {partition_id} is at the maximum LSN and cannot be resumed"
+        );
+        artifacts.push(ResolvedArtifact {
+            partition: partition.clone(),
+            record,
+        });
+    }
+
+    Ok(RestorePlan {
+        descriptor,
+        artifacts,
+        target_fingerprint,
+        restore_schema: options.restore_schema,
+        provider,
+        source_repository,
+    })
+}
+
+/// Applies a preflighted V0 restore. Each already-validated artifact is downloaded and imported
+/// before moving to the next one, bounding restore staging space to one partition snapshot. No
+/// cluster metadata is published until every partition is imported. `PartitionTable` is published
+/// last, so node initialization and worker roles remain blocked until imported stores and their
+/// epoch floors are in place.
+pub async fn apply(
+    plan: RestorePlan,
+    metadata_writer: &MetadataWriter,
+    common_options: &CommonOptions,
+    partition_store_manager: &PartitionStoreManager,
+) -> anyhow::Result<bool> {
+    let provider = plan.provider;
+    let source_cluster_features = plan.descriptor.source_cluster_features;
+    let mut imported_partitions = Vec::with_capacity(plan.artifacts.len());
+    for artifact in plan.artifacts {
+        let minimum_applied_lsn = artifact.record.min_applied_lsn;
+        let snapshot = plan
+            .source_repository
+            .download_record(artifact.record)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed downloading snapshot for partition {}",
+                    artifact.partition.partition_id
+                )
+            })?;
+        let partition = artifact.partition;
+        let mut store = partition_store_manager
+            .open_from_snapshot(&partition, snapshot)
+            .await
+            .with_context(|| {
+                format!(
+                    "failed importing snapshot for partition {}",
+                    partition.partition_id
+                )
+            })?;
+        let applied_lsn = store
+            .get_applied_lsn()
+            .await
+            .with_context(|| {
+                format!(
+                    "failed reading imported applied LSN for partition {}",
+                    partition.partition_id
+                )
+            })?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "imported snapshot for partition {} has no applied LSN",
+                    partition.partition_id
+                )
+            })?;
+        ensure!(
+            applied_lsn >= minimum_applied_lsn,
+            "imported applied LSN {applied_lsn} is below snapshot lower bound {minimum_applied_lsn} for partition {}",
+            partition.partition_id
+        );
+        ensure!(
+            applied_lsn != Lsn::MAX,
+            "imported snapshot for partition {} is at the maximum LSN and cannot be resumed",
+            partition.partition_id
+        );
+        let cached_epoch = store.get_partition_config_state().await.with_context(|| {
+            format!(
+                "failed reading imported epoch state for partition {}",
+                partition.partition_id
+            )
+        })?;
+        if !plan.restore_schema {
+            let mut transaction = store.transaction();
+            transaction.delete_schema().with_context(|| {
+                format!(
+                    "failed removing imported schema for partition {}",
+                    partition.partition_id
+                )
+            })?;
+            transaction.commit().await.with_context(|| {
+                format!(
+                    "failed committing schema removal for partition {}",
+                    partition.partition_id
+                )
+            })?;
+        }
+        imported_partitions.push(ImportedPartition {
+            partition,
+            cached_epoch,
+            applied_lsn,
+        });
+    }
+
+    // Build chains from the state actually imported from the SST, not the repository metadata's
+    // conservative lower bound. Reusing already-applied sequence numbers can make the restored
+    // state machine silently discard new commands.
+    let logs = bootstrap_target_logs(&imported_partitions, provider)?;
+
+    let nodes_configuration = create_initial_nodes_configuration_with_fingerprint(
+        common_options,
+        source_cluster_features,
+        plan.target_fingerprint,
+    );
+    let newly_provisioned = metadata_writer
+        .raw_metadata_store_client()
+        .provision(&nodes_configuration)
+        .await
+        .context("failed reserving the unprovisioned target cluster")?;
+    if !newly_provisioned {
+        return Ok(false);
+    }
+
+    write_initial_logs_dont_fail_if_it_exists(metadata_writer, logs)
+        .await
+        .context("failed writing restored log metadata")?;
+
+    for imported in imported_partitions {
+        let partition = imported.partition;
+        let (version_floor, epoch_floor) = imported
+            .cached_epoch
+            .map(|cached| (cached.version, cached.leader_epoch))
+            .unwrap_or_else(|| (Version::INVALID, Default::default()));
+        let epoch = EpochMetadata::bootstrap_after(
+            PartitionConfiguration::new(
+                ReplicationProperty::new_unchecked(1),
+                NodeSet::from_single(GenerationalNodeId::INITIAL_NODE_ID.as_plain()),
+                Default::default(),
+            ),
+            version_floor,
+            epoch_floor,
+        );
+        metadata_writer
+            .raw_metadata_store_client()
+            .put(
+                partition_processor_epoch_key(partition.partition_id),
+                &epoch,
+                Precondition::DoesNotExist,
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "failed seeding epoch metadata for partition {}",
+                    partition.partition_id
+                )
+            })?;
+    }
+
+    if plan.restore_schema
+        && let Some(schema) = plan.descriptor.schema
+    {
+        write_initial_value_dont_fail_if_it_exists(metadata_writer, Arc::new(schema))
+            .await
+            .context("failed writing restored schema")?;
+    }
+
+    let partition_table = single_node_partition_table(plan.descriptor.partition_table);
+    write_initial_value_dont_fail_if_it_exists(metadata_writer, Arc::new(partition_table))
+        .await
+        .context("failed writing restored partition table")?;
+
+    Ok(true)
+}
+
+pub(crate) fn validate_target_configuration(
+    common_options: &CommonOptions,
+    provider: ProviderKind,
+) -> anyhow::Result<()> {
+    ensure!(
+        !common_options.auto_provision,
+        "cluster restore requires auto-provision to be disabled"
+    );
+    ensure!(
+        common_options
+            .force_node_id
+            .is_none_or(|node_id| { node_id == GenerationalNodeId::INITIAL_NODE_ID.as_plain() }),
+        "cluster restore requires the bootstrap node ID to be {} when force-node-id is configured",
+        GenerationalNodeId::INITIAL_NODE_ID.as_plain()
+    );
+    ensure!(
+        common_options.roles.contains(Role::Worker),
+        "cluster restore requires the bootstrap node to have the worker role"
+    );
+    ensure!(
+        common_options.roles.contains(Role::MetadataServer)
+            && matches!(
+                &common_options.metadata_client.kind,
+                MetadataClientKind::Replicated { .. }
+            ),
+        "V0 cluster restore requires the bootstrap node to host the built-in metadata server; external metadata backends need a durable pre-import reservation protocol"
+    );
+    if provider == ProviderKind::Replicated {
+        ensure!(
+            common_options.roles.contains(Role::LogServer),
+            "the replicated log provider requires the bootstrap node to have the log-server role"
+        );
+    }
+    ensure!(
+        provider != ProviderKind::InMemory,
+        "cluster restore cannot use the non-durable in-memory log provider"
+    );
+    Ok(())
+}
+
+fn normalized_repository_root(repository: &str, description: &str) -> anyhow::Result<url::Url> {
+    let mut repository =
+        url::Url::parse(repository).with_context(|| format!("failed parsing {description} URL"))?;
+    // Keep this aligned with SnapshotRepository construction: query parameters configure the
+    // object-store client and are not part of the repository object prefix.
+    repository.set_query(None);
+    // object_store::path treats a non-root trailing slash as the same prefix. Normalize it here so
+    // source/target alias detection uses object-namespace semantics rather than URL spelling.
+    if repository.path() != "/" {
+        let path = repository.path().trim_end_matches('/').to_owned();
+        repository.set_path(&path);
+    }
+    Ok(repository)
+}
+
+fn ensure_distinct_repository_roots(
+    source: &url::Url,
+    snapshots_options: &SnapshotsOptions,
+) -> anyhow::Result<()> {
+    let Some(target) = snapshots_options.destination.as_deref() else {
+        return Ok(());
+    };
+    let target = normalized_repository_root(target, "target snapshot repository")?;
+    ensure!(
+        source != &target,
+        "the restored cluster's active snapshot repository must differ from the backup source repository"
+    );
+    Ok(())
+}
+
+fn target_fingerprint(
+    preserve: bool,
+    source: Option<ClusterFingerprint>,
+) -> anyhow::Result<ClusterFingerprint> {
+    match (preserve, source) {
+        (true, Some(fingerprint)) => Ok(fingerprint),
+        (true, None) => bail!(
+            "preserving the cluster fingerprint requires a source fingerprint in the backup descriptor"
+        ),
+        (false, _) => Ok(ClusterFingerprint::generate()),
+    }
+}
+
+fn exact_artifact(
+    descriptor: &ClusterBackupDescriptor,
+    partition_id: restate_types::identifiers::PartitionId,
+) -> anyhow::Result<&PartitionBackupArtifact> {
+    descriptor
+        .artifacts
+        .as_ref()
+        .and_then(|artifacts| {
+            artifacts
+                .iter()
+                .find(|artifact| artifact.partition_id == partition_id)
+        })
+        .ok_or_else(|| anyhow::anyhow!("missing exact artifact for partition {partition_id}"))
+}
+
+fn validate_record(partition: &Partition, record: &SnapshotRecord) -> anyhow::Result<()> {
+    ensure!(
+        record.partition_id == partition.partition_id
+            && record.metadata.partition_id == partition.partition_id,
+        "snapshot record does not match partition {}",
+        partition.partition_id
+    );
+    ensure!(
+        record.metadata.key_range == partition.key_range,
+        "snapshot key range does not match captured topology for partition {}",
+        partition.partition_id
+    );
+    ensure!(
+        record.metadata.log_id == partition.log_id(),
+        "snapshot log id does not match captured topology for partition {}",
+        partition.partition_id
+    );
+    ensure!(
+        record.metadata.min_applied_lsn == record.min_applied_lsn,
+        "snapshot minimum applied LSN is inconsistent for partition {}",
+        partition.partition_id
+    );
+    Ok(())
+}
+
+fn single_node_partition_table(partition_table: PartitionTable) -> PartitionTable {
+    let mut builder = PartitionTableBuilder::from(partition_table);
+    builder.set_partition_replication(PartitionReplication::Limit(
+        ReplicationProperty::new_unchecked(1),
+    ));
+    builder.build()
+}
+
+fn bootstrap_target_logs(
+    imported_partitions: &[ImportedPartition],
+    provider: ProviderKind,
+) -> anyhow::Result<Logs> {
+    let mut builder = LogsBuilder::default();
+    builder.set_configuration(LogsConfiguration::from(ProviderConfiguration::from((
+        provider,
+        ReplicationProperty::new_unchecked(1),
+        restate_types::logs::metadata::NodeSetSize::new(1).expect("one is a valid nodeset size"),
+    ))));
+
+    for imported in imported_partitions {
+        let log_id = imported.partition.log_id();
+        let params = match provider {
+            ProviderKind::Local | ProviderKind::InMemory => new_single_node_loglet_params(provider),
+            ProviderKind::Replicated => LogletParams::from(
+                ReplicatedLogletParams {
+                    loglet_id: LogletId::new(log_id, SegmentIndex::OLDEST),
+                    sequencer: GenerationalNodeId::INITIAL_NODE_ID,
+                    replication: ReplicationProperty::new_unchecked(1),
+                    nodeset: NodeSet::from_single(GenerationalNodeId::INITIAL_NODE_ID.as_plain()),
+                }
+                .serialize()?,
+            ),
+        };
+        builder.add_log(
+            log_id,
+            Chain::with_base_lsn(resume_lsn(log_id, imported.applied_lsn)?, provider, params),
+        )?;
+    }
+    Ok(builder.build())
+}
+
+fn resume_lsn(log_id: LogId, applied_lsn: Lsn) -> anyhow::Result<Lsn> {
+    ensure!(
+        applied_lsn != Lsn::MAX,
+        "log {log_id} is at the maximum LSN and cannot be resumed"
+    );
+    Ok(applied_lsn.next())
+}
+
+#[cfg(test)]
+mod tests {
+    use restate_types::partition_table::PartitionTable;
+
+    use super::*;
+
+    #[test]
+    fn single_node_partition_table_keeps_topology_but_sets_replication_to_one() {
+        let table = PartitionTable::with_equally_sized_partitions(Version::MIN, 2);
+        let restored = single_node_partition_table(table.clone());
+
+        assert_eq!(restored.len(), table.len());
+        assert_eq!(
+            restored.replication(),
+            &PartitionReplication::Limit(ReplicationProperty::new_unchecked(1))
+        );
+        for (partition_id, partition) in table.iter() {
+            assert_eq!(restored.get(partition_id), Some(partition));
+        }
+    }
+
+    #[test]
+    fn target_fingerprint_is_fresh_unless_preserved() {
+        let source = ClusterFingerprint::generate();
+
+        assert_eq!(target_fingerprint(true, Some(source)).unwrap(), source);
+        assert!(target_fingerprint(true, None).is_err());
+        assert_ne!(target_fingerprint(false, Some(source)).unwrap(), source);
+    }
+
+    #[test]
+    fn resume_lsn_rejects_overflow() {
+        assert_eq!(
+            resume_lsn(LogId::new(1), Lsn::new(41)).unwrap(),
+            Lsn::new(42)
+        );
+        assert!(resume_lsn(LogId::new(1), Lsn::MAX).is_err());
+    }
+
+    #[test]
+    fn target_configuration_requires_durable_single_node_roles() {
+        assert!(
+            validate_target_configuration(&CommonOptions::default(), ProviderKind::Replicated)
+                .is_err()
+        );
+
+        let mut common = CommonOptions::default();
+        common.auto_provision = false;
+        assert!(validate_target_configuration(&common, ProviderKind::Replicated).is_ok());
+
+        common.force_node_id = Some(restate_types::PlainNodeId::new(2));
+        assert!(validate_target_configuration(&common, ProviderKind::Replicated).is_err());
+        common.force_node_id = Some(GenerationalNodeId::INITIAL_NODE_ID.as_plain());
+        assert!(validate_target_configuration(&common, ProviderKind::Replicated).is_ok());
+
+        common.roles.remove(Role::Worker);
+        assert!(validate_target_configuration(&common, ProviderKind::Replicated).is_err());
+        common.roles.insert(Role::Worker);
+
+        common.roles.remove(Role::LogServer);
+        assert!(validate_target_configuration(&common, ProviderKind::Replicated).is_err());
+        assert!(validate_target_configuration(&common, ProviderKind::Local).is_ok());
+        assert!(validate_target_configuration(&common, ProviderKind::InMemory).is_err());
+
+        common.roles.insert(Role::LogServer);
+        common.metadata_client.kind = MetadataClientKind::Etcd {
+            addresses: Vec::new(),
+        };
+        assert!(validate_target_configuration(&common, ProviderKind::Replicated).is_err());
+    }
+
+    #[test]
+    fn active_repository_must_differ_from_restore_source() {
+        let source = normalized_repository_root(
+            "s3://bucket/source?region=source",
+            "source snapshot repository",
+        )
+        .unwrap();
+        let mut snapshots = SnapshotsOptions::default();
+
+        assert!(ensure_distinct_repository_roots(&source, &snapshots).is_ok());
+        snapshots.destination = Some("s3://bucket/target?region=target".to_owned());
+        assert!(ensure_distinct_repository_roots(&source, &snapshots).is_ok());
+
+        snapshots.destination = Some("s3://bucket/source?region=target".to_owned());
+        assert!(ensure_distinct_repository_roots(&source, &snapshots).is_err());
+
+        snapshots.destination = Some("s3://bucket/source/?region=target".to_owned());
+        assert!(ensure_distinct_repository_roots(&source, &snapshots).is_err());
+
+        snapshots.destination = Some("s3://bucket/source/restored".to_owned());
+        assert!(ensure_distinct_repository_roots(&source, &snapshots).is_ok());
+    }
+}

--- a/crates/partition-store/src/fsm_table/mod.rs
+++ b/crates/partition-store/src/fsm_table/mod.rs
@@ -409,6 +409,12 @@ impl WriteFsmTable for PartitionStoreTransaction<'_> {
         self.put_kv_storage_codec(key, schema)
     }
 
+    fn delete_schema(&mut self) -> Result<()> {
+        let key = create_key(self.partition_id(), fsm_variable::SERVICES_SCHEMA_METADATA);
+        self.raw_delete_cf(KeyKind::Fsm, key.to_bytes());
+        Ok(())
+    }
+
     fn put_partition_config_state(&mut self, state: &CachedEpochMetadata) -> Result<()> {
         let key = create_key(self.partition_id(), fsm_variable::PARTITION_CONFIG_STATE);
         self.put_kv_storage_codec(key, state)

--- a/crates/partition-store/src/tests/fsm_table_test.rs
+++ b/crates/partition-store/src/tests/fsm_table_test.rs
@@ -1,0 +1,34 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use restate_storage_api::Transaction;
+use restate_storage_api::fsm_table::{ReadFsmTable, WriteFsmTable};
+use restate_types::schema::Schema;
+
+use super::storage_test_environment;
+
+#[restate_core::test]
+async fn deleting_cached_schema_is_durable() -> googletest::Result<()> {
+    let mut store = storage_test_environment().await;
+
+    let mut transaction = store.transaction();
+    transaction.put_schema(&Schema::default())?;
+    transaction.commit().await?;
+    drop(transaction);
+    assert!(store.get_schema().await?.is_some());
+
+    let mut transaction = store.transaction();
+    transaction.delete_schema()?;
+    transaction.commit().await?;
+    drop(transaction);
+    assert!(store.get_schema().await?.is_none());
+
+    Ok(())
+}

--- a/crates/partition-store/src/tests/mod.rs
+++ b/crates/partition-store/src/tests/mod.rs
@@ -30,6 +30,7 @@ use restate_types::state_mut::ExternalStateMutation;
 
 mod barrier_test;
 mod durable_lsn_tracking_test;
+mod fsm_table_test;
 mod inbox_table_test;
 mod invocation_status_table_test;
 mod journal_events_table_test;

--- a/crates/storage-api/src/fsm_table/mod.rs
+++ b/crates/storage-api/src/fsm_table/mod.rs
@@ -80,6 +80,9 @@ pub trait WriteFsmTable {
 
     fn put_schema(&mut self, schema: &Schema) -> Result<()>;
 
+    /// Removes the partition-local cached service schema.
+    fn delete_schema(&mut self) -> Result<()>;
+
     fn put_partition_config_state(&mut self, state: &CachedEpochMetadata) -> Result<()>;
 
     /// Persist the rule book for this partition.

--- a/crates/types/src/epoch.rs
+++ b/crates/types/src/epoch.rs
@@ -53,6 +53,27 @@ impl EpochMetadata {
         }
     }
 
+    /// Creates epoch metadata for a bootstrap that must supersede a value imported with a
+    /// partition snapshot. Both the metadata version and leader epoch are strictly greater than
+    /// their respective floors, so the first leadership announcement is not rejected as stale.
+    pub fn bootstrap_after(
+        mut current: PartitionConfiguration,
+        version_floor: Version,
+        epoch_floor: LeaderEpoch,
+    ) -> Self {
+        let version = version_floor.max(Version::MIN).next();
+        current.version = version;
+
+        Self {
+            version,
+            leader_metadata: None,
+            epoch: epoch_floor.max(LeaderEpoch::INITIAL).next(),
+            current,
+            next: None,
+            leadership_policy: LeadershipPolicy::default(),
+        }
+    }
+
     pub fn into_inner(
         self,
     ) -> (
@@ -212,12 +233,12 @@ mod compatibility {
 
 #[cfg(test)]
 mod tests {
-    use crate::GenerationalNodeId;
     use crate::epoch::{EpochMetadata, PartitionConfiguration};
     use crate::identifiers::{LeaderEpoch, PartitionId};
     use crate::replication::ReplicationProperty;
     use crate::storage::StorageCodec;
     use crate::version::Versioned;
+    use crate::{GenerationalNodeId, Version};
     use bytes::BytesMut;
     use std::collections::HashMap;
 
@@ -271,5 +292,25 @@ mod tests {
             deserialized_epoch_metadata.version()
         );
         assert_eq!(epoch_metadata.epoch(), deserialized_epoch_metadata.epoch());
+    }
+
+    #[test]
+    fn restore_bootstrap_supersedes_imported_epoch_floors() {
+        let version_floor = Version::from(10);
+        let epoch_floor = LeaderEpoch::from(20);
+        let epoch_metadata = EpochMetadata::bootstrap_after(
+            PartitionConfiguration::default(),
+            version_floor,
+            epoch_floor,
+        );
+
+        assert!(epoch_metadata.version() > version_floor);
+        assert!(epoch_metadata.current().version() > version_floor);
+        assert!(epoch_metadata.epoch() > epoch_floor);
+
+        let claimed =
+            epoch_metadata.claim_leadership(GenerationalNodeId::INITIAL_NODE_ID, PartitionId::MIN);
+        assert!(claimed.version() > version_floor);
+        assert!(claimed.epoch() > epoch_floor);
     }
 }

--- a/tools/restatectl/src/commands/snapshot/mod.rs
+++ b/tools/restatectl/src/commands/snapshot/mod.rs
@@ -10,6 +10,7 @@
 
 mod backup;
 mod create_snapshot;
+mod restore;
 
 use cling::prelude::*;
 
@@ -20,4 +21,6 @@ pub enum Snapshot {
     Backup(backup::BackupOpts),
     /// Create.
     CreateSnapshot(create_snapshot::CreateSnapshotOpts),
+    /// Restore a V0 cluster backup descriptor onto an unprovisioned node.
+    Restore(restore::RestoreOpts),
 }

--- a/tools/restatectl/src/commands/snapshot/restore.rs
+++ b/tools/restatectl/src/commands/snapshot/restore.rs
@@ -1,0 +1,195 @@
+// Copyright (c) 2023 - 2026 Restate Software, Inc., Restate GmbH.
+// All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::path::PathBuf;
+
+use cling::prelude::*;
+
+use restate_cli_util::ui::console::confirm_or_exit;
+use restate_cli_util::{CliContext, c_println, c_warn};
+use restate_core::protobuf::node_ctl_svc::{
+    RestoreClusterRequest, RestoreClusterResponse, new_node_ctl_client,
+};
+use restate_types::cluster_backup::{BackupArtifactSet, ClusterBackupDescriptor};
+
+use crate::connection::ConnectionInfo;
+use crate::util::grpc_channel;
+
+#[derive(Run, Parser, Collect, Clone, Debug)]
+#[cling(run = "restore")]
+pub struct RestoreOpts {
+    /// Path to a V0 cluster backup descriptor JSON file.
+    #[arg(long, value_hint = clap::ValueHint::FilePath)]
+    input: PathBuf,
+
+    /// Restore the schema captured in the backup descriptor.
+    #[arg(long)]
+    restore_schema: bool,
+
+    /// Keep the source cluster fingerprint instead of generating a new one.
+    #[arg(long)]
+    preserve_cluster_fingerprint: bool,
+
+    /// Validate the restore on the target node without changing it.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+async fn restore(connection: &ConnectionInfo, opts: &RestoreOpts) -> anyhow::Result<()> {
+    let descriptor_json = tokio::fs::read(&opts.input).await?;
+    let descriptor = parse_descriptor(
+        &descriptor_json,
+        opts.restore_schema,
+        opts.preserve_cluster_fingerprint,
+    )?;
+
+    let address = connection.single_address.as_ref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "snapshots restore requires an explicitly addressed node; pass --single-address <address>"
+        )
+    })?;
+    let mut client = new_node_ctl_client(grpc_channel(address.clone()), &CliContext::get().network);
+
+    let ident = client.get_ident(()).await?.into_inner();
+    if ident.node_id.is_some() {
+        anyhow::bail!("refusing to restore onto {address}: the target node is already provisioned");
+    }
+
+    c_warn!(
+        "V0 backups are best-effort and not a consistent cluster-wide cut. This restores all partitions onto one bootstrap node and replaces its cluster metadata and partition state. Ensure the target is empty and unprovisioned."
+    );
+    c_println!(
+        "Backup source: cluster '{}' ({} partitions).",
+        descriptor.source_cluster_name,
+        descriptor.partition_table.len()
+    );
+
+    if !opts.dry_run {
+        confirm_or_exit("Restore this backup onto the target node?")?;
+    }
+
+    let response = client
+        .restore_cluster(RestoreClusterRequest {
+            descriptor_json: descriptor_json.into(),
+            restore_schema: opts.restore_schema,
+            preserve_cluster_fingerprint: opts.preserve_cluster_fingerprint,
+            dry_run: opts.dry_run,
+        })
+        .await?
+        .into_inner();
+
+    print_response(&response);
+    Ok(())
+}
+
+fn parse_descriptor(
+    descriptor_json: &[u8],
+    restore_schema: bool,
+    preserve_cluster_fingerprint: bool,
+) -> anyhow::Result<ClusterBackupDescriptor> {
+    let descriptor = serde_json::from_slice::<ClusterBackupDescriptor>(descriptor_json)
+        .map_err(|error| anyhow::anyhow!("invalid backup descriptor JSON: {error}"))?;
+    match descriptor.validate()? {
+        BackupArtifactSet::TopologyOnly | BackupArtifactSet::Complete => {}
+        BackupArtifactSet::Incomplete => {
+            anyhow::bail!("backup descriptor is incomplete and cannot be restored");
+        }
+    }
+    if restore_schema && descriptor.schema.is_none() {
+        anyhow::bail!("--restore-schema requires a backup descriptor containing a schema");
+    }
+    if preserve_cluster_fingerprint && descriptor.source_cluster_fingerprint.is_none() {
+        anyhow::bail!(
+            "--preserve-cluster-fingerprint requires a backup descriptor containing a source cluster fingerprint"
+        );
+    }
+    Ok(descriptor)
+}
+
+fn print_response(response: &RestoreClusterResponse) {
+    let mode = if response.dry_run {
+        "Restore validation succeeded"
+    } else {
+        "Cluster restore succeeded"
+    };
+    c_println!("{mode}.");
+    c_println!("Target cluster: {}", response.target_cluster_name);
+    if let Some(fingerprint) = &response.target_cluster_fingerprint {
+        c_println!("Target cluster fingerprint: {fingerprint}");
+    }
+    c_println!(
+        "{} partitions: {}",
+        if response.dry_run {
+            "Validated"
+        } else {
+            "Restored"
+        },
+        response.partition_count
+    );
+    c_println!(
+        "Schema {}: {}",
+        if response.dry_run {
+            "would be restored"
+        } else {
+            "restored"
+        },
+        if response.schema_restored {
+            "yes"
+        } else {
+            "no"
+        }
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use restate_types::Version;
+    use restate_types::cluster_backup::{BackupConsistency, ClusterBackupDescriptor};
+    use restate_types::partition_table::PartitionTable;
+    use restate_types::time::MillisSinceEpoch;
+
+    use super::parse_descriptor;
+
+    fn descriptor_json() -> Vec<u8> {
+        serde_json::to_vec(&ClusterBackupDescriptor {
+            version: ClusterBackupDescriptor::VERSION,
+            created_at: MillisSinceEpoch::new(1),
+            consistency: BackupConsistency::BestEffort,
+            source_snapshot_repository: "s3://bucket/backups".to_owned(),
+            source_cluster_name: "source".to_owned(),
+            source_cluster_fingerprint: None,
+            source_cluster_features: Default::default(),
+            partition_table: PartitionTable::with_equally_sized_partitions(Version::MIN, 2),
+            schema: None,
+            artifacts: None,
+            failures: vec![],
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn parses_a_valid_topology_only_descriptor() {
+        let descriptor = parse_descriptor(&descriptor_json(), false, false).unwrap();
+
+        assert_eq!(descriptor.source_cluster_name, "source");
+        assert_eq!(descriptor.partition_table.len(), 2);
+    }
+
+    #[test]
+    fn restore_options_require_their_descriptor_data() {
+        let error = parse_descriptor(&descriptor_json(), true, false).unwrap_err();
+
+        assert!(error.to_string().contains("--restore-schema"));
+
+        let error = parse_descriptor(&descriptor_json(), false, true).unwrap_err();
+
+        assert!(error.to_string().contains("--preserve-cluster-fingerprint"));
+    }
+}


### PR DESCRIPTION
Experimental recovery stack — PR 2 of 3.

Adds immutable snapshot preflight/download from an explicit source repository, plus `restatectl snapshots restore` and a node restore RPC. Restore downloads and imports one preflighted partition at a time to bound staging space, resumes each log after the applied LSN actually found in the imported store, bootstraps newer partition epochs, optionally restores or durably removes cached deployment schema, and provisions a fresh single-node topology last.

Safety checks require a directly addressed, unprovisioned, non-auto-provisioning built-in-metadata node with the required durable roles. Forced node IDs must be the initial ID; source and active target repositories must be distinct; unsupported feature sets and invalid/incomplete snapshot topology fail before mutation. Dry-run performs the same preflight without provisioning.

Operational limitation: after metadata provisioning begins, a crash or transient failure is not retryable in V0; discard the fresh target and retry.

Stack: depends on PR 1.